### PR TITLE
Added Ability to set $_properties via array key also.

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -298,17 +298,17 @@ class Model implements \ArrayAccess, \Iterator {
 		// Return Query object
 		if (is_null($id))
 		{
-			return Query::factory(get_called_class());
+			return static::query();
 		}
 		// Return all that match $options array
 		elseif ($id == 'all')
 		{
-			return Query::factory(get_called_class(), $options)->get();
+			return static::query($options)->get();
 		}
 		// Return first or last row that matches $options array
 		elseif ($id == 'first' or $id == 'last')
 		{
-			$query = Query::factory(get_called_class(), $options);
+			$query = static::query($options);
 
 			foreach(static::primary_key() as $pk)
 			{
@@ -337,8 +337,19 @@ class Model implements \ArrayAccess, \Iterator {
 
 			array_key_exists('where', $options) and $where = array_merge($options['where'], $where);
 			$options['where'] = $where;
-			return Query::factory(get_called_class(), $options)->get_one();
+			return static::query($options)->get_one();
 		}
+	}
+
+	/**
+	 * Creates a new query with optional settings up front
+	 *
+	 * @param   array
+	 * @return  Query
+	 */
+	public static function query($options = array())
+	{
+		return Query::factory(get_called_class(), $options);
 	}
 
 	/**

--- a/classes/model.php
+++ b/classes/model.php
@@ -184,8 +184,18 @@ class Model implements \ArrayAccess, \Iterator {
 			{
 				if (is_string($p))
 				{
-					unset($properties[$key]);
-					$properties[$p] = array();
+					// if the $key is an integer proceed normally
+					if (is_int($key))
+					{
+						unset($properties[$key]);
+						$properties[$p] = array();
+					}
+					// this allows you to set $_properties of the model with the property as the key
+					else
+					{
+						unset($properties[$key]);
+						$properties[$key] = array();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I'm working on a bigger feature in which I need to declare the ORM models like this

```
class Model_Article extends Orm\Model {
    protected static $_properties = array('id' => 'integer', 'title' => 'string', 'contents' => 'text' , 'publish' => 'int[1]');
}
```

I don't believe this change will disrupt any of the current functionality.

Also, not really sure why commit 3260ecf is in there...
