### PR TITLE
In find method, pass $options to query object even if $id is null.  

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -298,7 +298,7 @@ class Model implements \ArrayAccess, \Iterator {
 		// Return Query object
 		if (is_null($id))
 		{
-			return static::query();
+			return static::query($options);
 		}
 		// Return all that match $options array
 		elseif ($id == 'all')


### PR DESCRIPTION
Does no harm if you use find method as usually and helps if you overrides the find method in your models:

namespace Content;

class Model_page extends \Content\Model_content {

public static function find($id = null, array $options = array())
{
$where[] = array('module','=','pages');
array_key_exists('where', $options) and $where = array_merge($options['where'],$where);
$options['where'] = $where;
return parent::find($id,$options);
}

}
