### PR TITLE
Made manymany relationships save() and delete() take account of the different database in $_connection of the from model

### DIFF
--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -216,7 +216,7 @@ class ManyMany extends Relation {
 					next($this->key_to);
 				}
 
-				\DB::insert($this->table_through)->set($ids)->execute();
+				\DB::insert($this->table_through)->set($ids)->execute(call_user_func(array($model_from, 'connection')));
 				$original_model_ids[] = $current_model_id; // prevents inserting it a second time
 			}
 			else
@@ -260,7 +260,7 @@ class ManyMany extends Relation {
 				next($to_keys);
 			}
 
-			$query->execute();
+			$query->execute(call_user_func(array($model_from, 'connection')));
 		}
 
 		$cascade = is_null($cascade) ? $this->cascade_save : (bool) $cascade;
@@ -295,7 +295,7 @@ class ManyMany extends Relation {
 			$query->where($key, '=', $model_from->{current($this->key_from)});
 			next($this->key_from);
 		}
-		$query->execute();
+		$query->execute(call_user_func(array($model_from, 'connection')));
 
 		$cascade = is_null($cascade) ? $this->cascade_delete : (bool) $cascade;
 		if ($cascade and ! empty($model_to))


### PR DESCRIPTION
Currently this causes an error as it tries to connect to the current environment's database

This doesn't seem to be an issue in any of the other relationship types as they don't directly call execute() on a Query object.
