### PR TITLE
If the fieldset is loaded from an instance, readding the fields causes an

### DIFF
--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -40,7 +40,7 @@ class Observer_Validation extends Observer {
 
 		foreach ($properties as $p => $settings)
 		{
-			$field = $fieldset->add($p, ! empty($settings['label']) ? $settings['label'] : $p);
+			$field = $fieldset->field($p) ? $fieldset->field($p) : $fieldset->add($p, ! empty($settings['label']) ? $settings['label'] : $p);
 			if (empty($settings['validation']))
 			{
 				continue;


### PR DESCRIPTION
If the fieldset is loaded from an instance, readding the fields causes an error. If the field already exists in the fieldset, don't add it again. Fixes #50

I'm not sure if this is the most elegant fix, but it works.
