### PR TITLE
Bug fix and feature addition to Validaiton observer

### DIFF
--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -25,8 +25,9 @@ class Observer_Validation extends Observer {
 	 * @param   Fieldset|null
 	 * @return  Fieldset
 	 */
-	public static function set_fields($class, $fieldset = null)
+	public static function set_fields($obj, $fieldset = null)
 	{
+		$class = get_class($obj);
 		$properties = $class::properties();
 
 		if (is_null($fieldset))
@@ -38,9 +39,11 @@ class Observer_Validation extends Observer {
 			}
 		}
 
+		$fieldset->validation()->add_callable($obj);
+
 		foreach ($properties as $p => $settings)
 		{
-			$field = $fieldset->add($p, ! empty($settings['label']) ? $settings['label'] : $p);
+			$field = $fieldset->field($p) ? $fieldset->field($p) : $fieldset->add($p, ! empty($settings['label']) ? $settings['label'] : $p);
 			if (empty($settings['validation']))
 			{
 				continue;
@@ -91,7 +94,7 @@ class Observer_Validation extends Observer {
 	 */
 	public function validate(Model $obj)
 	{
-		$val = static::set_fields(get_class($obj))->validation();
+		$val = static::set_fields($obj)->validation();
 
 		$input = array();
 		foreach ($obj as $k => $v)

--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -63,6 +63,12 @@ class Observer_Validation extends Observer {
 			}
 		}
 
+		// Add related fields to the validation to prevent them being stripped
+		$val = $fieldset->validation();
+		foreach ($class::relations() as $name=>$relation) {
+			$val->add($name);
+		}
+
 		return $fieldset;
 	}
 

--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -80,6 +80,17 @@ class Observer_Validation extends Observer {
 	 */
 	public function before_save(Model $obj)
 	{
+		$this->validate($obj);
+	}
+
+	/**
+	 * Execute to do validation without saving
+	 *
+	 * @param	Model
+	 * @throws	ValidationFailed
+	 */
+	public function validate(Model $obj)
+	{
 		$val = static::set_fields(get_class($obj))->validation();
 
 		$input = array();

--- a/classes/query.php
+++ b/classes/query.php
@@ -773,7 +773,7 @@ class Query {
 
 		// attach the retrieved relations to the object and update its original DB values
 		$obj->_relate($rel_objs);
-		$obj->_update_original();
+		$obj->_update_original_relations();
 
 		return $obj;
 	}


### PR DESCRIPTION
Bug fix concerns using related fields on a model which is being validated with the validation observer. When this code executes...

<code>
foreach ($input as $k => $v)
{
    $obj->{$k} = $val->validated($k);
}
</code>

$val->validated('related_field_name') returns false as the related field is not known to the validation object.

The fix adds related fields to the object to ensure validation doesn't replace the array with false. Validation of related fields would be handled using observers in the related model classes.

The feature addition allows a user to do $model->observe('validate') to manually initiate validation. This is useful on the odd occasion you wish to validate without saving.
