### PR TITLE
Observer_Validation Changes

### DIFF
--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -19,7 +19,10 @@ class Observer_UpdatedAt extends Observer {
 
 	public function before_save(Model $obj)
 	{
-		$obj->{static::$property} = static::$mysql_timestamp ? \Date::time()->format('mysql') : \Date::time()->get_timestamp();
+		if ($obj->is_new() || $obj->is_changed())
+		{
+			$obj->{static::$property} = static::$mysql_timestamp ? \Date::time()->format('mysql') : \Date::time()->get_timestamp();
+		}
 	}
 }
 

--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -25,8 +25,9 @@ class Observer_Validation extends Observer {
 	 * @param   Fieldset|null
 	 * @return  Fieldset
 	 */
-	public static function set_fields($class, $fieldset = null)
+	public static function set_fields($obj, $fieldset = null)
 	{
+		$class = get_class($obj);
 		$properties = $class::properties();
 
 		if (is_null($fieldset))
@@ -38,9 +39,11 @@ class Observer_Validation extends Observer {
 			}
 		}
 
+		$fieldset->validation()->add_callable($obj);
+
 		foreach ($properties as $p => $settings)
 		{
-			$field = $fieldset->add($p, ! empty($settings['label']) ? $settings['label'] : $p);
+			$field = $fieldset->field($p) ? $fieldset->field($p) : $fieldset->add($p, ! empty($settings['label']) ? $settings['label'] : $p);
 			if (empty($settings['validation']))
 			{
 				continue;
@@ -91,7 +94,7 @@ class Observer_Validation extends Observer {
 	 */
 	public function validate(Model $obj)
 	{
-		$val = static::set_fields(get_class($obj))->validation();
+		$val = static::set_fields($obj)->validation();
 
 		$input = array();
 		foreach ($obj as $k => $v)

--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -63,6 +63,12 @@ class Observer_Validation extends Observer {
 			}
 		}
 
+		// Add related fields to the validation to prevent them being stripped
+		$val = $fieldset->validation();
+		foreach ($class::relations() as $name=>$relation) {
+			$val->add($name);
+		}
+
 		return $fieldset;
 	}
 

--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -80,6 +80,17 @@ class Observer_Validation extends Observer {
 	 */
 	public function before_save(Model $obj)
 	{
+		$this->validate($obj);
+	}
+
+	/**
+	 * Execute to do validation without saving
+	 *
+	 * @param	Model
+	 * @throws	ValidationFailed
+	 */
+	public function validate(Model $obj)
+	{
 		$val = static::set_fields(get_class($obj))->validation();
 
 		$input = array();


### PR DESCRIPTION
This is the product of a month or so of work and testing to make this observer fit for general purpose. We are using it (repackaged) internally now.

It's probably not perfect but it can likely be improved over time.

The fixes are, from what I recall, the following...

:: Pass an object instead of a class to allow callables to be added from it to allow for custom validation rules to be added to a model

:: Pull request from https://github.com/fuel/orm/pull/53 has been added to fix what was a fairly fundamental stumbling point in getting it to work

:: Created a validate() method to allow validation without saving

Thoughts?
