### PR TITLE
Flexibility with the way you use the Orm without impacting performance

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -564,18 +564,7 @@ class Model implements \ArrayAccess, \Iterator {
 
 		if ($new)
 		{
-			$properties = $this->properties();
-			foreach ($properties as $prop => $settings)
-			{
-				if (array_key_exists($prop, $data))
-				{
-					$this->_data[$prop] = $data[$prop];
-				}
-				elseif (array_key_exists('default', $settings))
-				{
-					$this->_data[$prop] = $settings['default'];
-				}
-			}
+			$this->values($data);
 		}
 		else
 		{
@@ -823,6 +812,34 @@ class Model implements \ArrayAccess, \Iterator {
 	public function uns($property)
 	{
 		$this->__unset($property);
+		return $this;
+	}
+
+	/**
+	 * Values
+	 * 
+	 * Short way of setting the values
+	 * for the object as opposed to setting
+	 * each one individually
+	 * 
+	 * @access  public
+	 * @param   array  $values
+	 * @return  Orm\Model
+	 */
+	public function values(Array $data)
+	{
+		$properties = $this->properties();
+		foreach ($properties as $prop => $settings)
+		{
+			if (array_key_exists($prop, $data))
+			{
+				$this->_data[$prop] = $data[$prop];
+			}
+			elseif (array_key_exists('default', $settings))
+			{
+				$this->_data[$prop] = $settings['default'];
+			}
+		}
 		return $this;
 	}
 

--- a/classes/model.php
+++ b/classes/model.php
@@ -246,7 +246,7 @@ class Model implements \ArrayAccess, \Iterator {
 			}
 			catch (\Exception $e)
 			{
-				throw new \Fuel_Exception('Listing columns not failed, you have to set the model properties with a '.
+				throw new \Fuel_Exception('Listing columns failed, you have to set the model properties with a '.
 					'static $_properties setting in the model. Original exception: '.$e->getMessage());
 			}
 		}

--- a/classes/model.php
+++ b/classes/model.php
@@ -776,6 +776,57 @@ class Model implements \ArrayAccess, \Iterator {
 	}
 
 	/**
+	 * Get
+	 * 
+	 * Gets a property or
+	 * relation from the
+	 * object
+	 * 
+	 * @access  public
+	 * @param   string  $property
+	 * @return  mixed
+	 */
+	public function get($property)
+	{
+		return $this->__get($property);
+	}
+
+	/**
+	 * Set
+	 * 
+	 * Sets a property or
+	 * relation of the
+	 * object
+	 * 
+	 * @access  public
+	 * @param   string  $property
+	 * @param   string  $value
+	 * @return  Orm\Model
+	 */
+	public function set($property, $value)
+	{
+		$this->__set($property, $value);
+		return $this;
+	}
+
+	/**
+	 * Uns
+	 * 
+	 * Unsets a property or
+	 * relation of the
+	 * object
+	 * 
+	 * @access  public
+	 * @param   string  $property
+	 * @return  Orm\Model
+	 */
+	public function uns($property)
+	{
+		$this->__unset($property);
+		return $this;
+	}
+
+	/**
 	 * Save the object and it's relations, create when necessary
 	 *
 	 * @param  mixed  $cascade
@@ -1270,6 +1321,33 @@ class Model implements \ArrayAccess, \Iterator {
 		}
 
 		return $array;
+	}
+
+	/**
+	 * Call
+	 * 
+	 * 
+	 */
+	public function __call($method, $args)
+	{
+		$convenience = substr($method, 0, 3);
+		$property    = substr($method, 4);
+
+		switch ($convenience)
+		{
+			case 'get':
+				return $this->get($property);
+				break;
+			case 'set':
+				return $this->set($property, reset($args));
+				break;
+			case 'uns':
+				return $this->uns($property);
+				break;
+		}
+
+		// Throw an exception
+		throw new \ErrorException('Call to undefined method '.get_class($this).'::'.$method.'()');
 	}
 }
 


### PR DESCRIPTION
Earlier today I spoke to @dhorrigan about chaining in the Session class. It got me thinking about the Orm.

Instead of setting properties each time, sometimes it is nice to have methods to set the properties, for two reasons:
1. It allows chaining
2. It allows you to override these methods in your model and manipulate the results before returning them.

After building this I realised a feature lacking from the Orm that Kohana's Orm has - a values() method - to reassign data to a model from an array - once again saving on typing.

This screenshot below demonstrates the enhanced usage from the attached commits:
http://d.pr/FcnR

And this one below demonstrates a huge advantage gained by using the convenience methods:
http://d.pr/uCMs

I'm aware that __call() has some performance implications, however as you'll see you don't have to use methods requiring __call(), but it adds a whole lot of power. The best part? If people don't want to use the Orm this way it won't affect them at all! This feature is needed IMO especially because the Orm is not designed to be easily overridden.
