### PR TITLE
1.1/develop Added a Slug Observer

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -28,6 +28,7 @@ Autoloader::add_classes(array(
 	'Orm\\Observer_UpdatedAt'   => __DIR__.'/classes/observer/updatedat.php',
 	'Orm\\Observer_Validation'  => __DIR__.'/classes/observer/validation.php',
 	'Orm\\Observer_Self'        => __DIR__.'/classes/observer/self.php',
+	'Orm\\Observer_Slug'        => __DIR__.'/classes/observer/slug.php',
 
 	// Exceptions
 	'Orm\\RecordNotFound'      => __DIR__.'/classes/model.php',

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -34,7 +34,7 @@ class Observer_Slug extends Observer {
 	{
 		$class = get_class($obj);
 		$slug  = \Inflector::friendly_title($obj->{static::$source}, '-', true);
-		$same  = $class::find()->where(static::$property, 'like', $slug.'%')->get();
+		$same  = $class::find()->where(static::$property, 'regexp', '^'.$slug.'(-[0-9]+)?$')->get();
 
 		if ( ! empty($same))
 		{

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package		Fuel
+ * @version		1.1
+ * @author		Fuel Development Team
+ * @license		MIT License
+ * @copyright	2010 - 2011 Fuel Development Team
+ * @link		http://fuelphp.com
+ */
+
+namespace Orm;
+
+class Observer_Slug extends Observer {
+
+	/**
+	 * @var string Source property, which is used to create the slug
+	 */
+	public static $source = 'title';
+	
+	/**
+	 * @var string Slug property
+	 */
+	public static $property = 'slug';
+
+	/**
+	 * Creates a unique slug and adds it to the object
+	 *
+	 * @param  Model The object
+	 * @return void
+	 */
+	public function before_insert(Model $obj)
+	{
+		$class = get_class($obj);
+		$slug  = \Inflector::friendly_title($obj->{static::$source}, '-', true);
+		$same  = $class::find()->where(static::$property, 'like', $slug.'%')->get();
+
+		if ( ! empty($same))
+		{
+			$max = 0;
+			
+			foreach ($same as $record)
+			{
+				$index = (int) preg_replace('/^[^\n]+-([0-9]+)$/', '\1', $record->slug);
+				$max < $index and $max = $index;
+			}
+			
+			$slug .= '-'.($max + 1);
+		}
+			
+		$obj->{static::$property} = $slug;
+	}
+}

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -42,7 +42,7 @@ class Observer_Slug extends Observer {
 			
 			foreach ($same as $record)
 			{
-				$index = (int) preg_replace('/^[^\n]+-([0-9]+)$/', '\1', $record->slug);
+				$index = (int) preg_replace('/^[^\n]+-([0-9]+)$/', '\1', $record->{static::$property});
 				$max < $index and $max = $index;
 			}
 			

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -33,19 +33,22 @@ class Observer_Slug extends Observer {
 	public function before_insert(Model $obj)
 	{
 		$slug  = \Inflector::friendly_title($obj->{static::$source}, '-', true);
-		$same  = $obj->find()->where(static::$property, 'regexp', '^'.$slug.'(-[0-9]+)?$')->get();
+		$same  = $obj->find()->where(static::$property, 'like', $slug.'%')->get();
 
 		if ( ! empty($same))
 		{
-			$max = 0;
+			$max = -1;
 			
 			foreach ($same as $record)
 			{
-				$index = (int) preg_replace('/^[^\n]+-([0-9]+)$/', '\1', $record->{static::$property});
-				$max < $index and $max = $index;
+				if (preg_match('/^'.$slug.'(-[0-9]+)?$/', $record->{static::$property}))
+				{
+					$index = (int) preg_replace('/^[^\n]+-([0-9]+)$/', '\1', $record->{static::$property});
+					$max < $index and $max = $index;
+				}
 			}
 			
-			$slug .= '-'.($max + 1);
+			$max < 0 or $slug .= '-'.($max + 1);
 		}
 			
 		$obj->{static::$property} = $slug;

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -32,9 +32,8 @@ class Observer_Slug extends Observer {
 	 */
 	public function before_insert(Model $obj)
 	{
-		$class = get_class($obj);
 		$slug  = \Inflector::friendly_title($obj->{static::$source}, '-', true);
-		$same  = $class::find()->where(static::$property, 'regexp', '^'.$slug.'(-[0-9]+)?$')->get();
+		$same  = $obj->find()->where(static::$property, 'regexp', '^'.$slug.'(-[0-9]+)?$')->get();
 
 		if ( ! empty($same))
 		{

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -41,10 +41,10 @@ class Observer_Slug extends Observer {
 			
 			foreach ($same as $record)
 			{
-				if (preg_match('/^'.$slug.'(-[0-9]+)?$/', $record->{static::$property}))
+				if (preg_match('/^'.$slug.'(?:-([0-9]+))?$/', $record->{static::$property}, $matches))
 				{
-					$index = (int) preg_replace('/^[^\n]+-([0-9]+)$/', '\1', $record->{static::$property});
-					$max < $index and $max = $index;
+				     $index = (int) $matches[1];
+				     $max < $index and $max = $index;
 				}
 			}
 			


### PR DESCRIPTION
The slug observer creates a unique slug for a model using Inflector::friendly_title() and adds an index, if the slug already exists.

```
Observer_Slug::$source   // is the property, which is given to Inflector::friendly_title()
Observer_Slug::$property // is the property for the slug
```

Maybe this is something for you.
