### PR TITLE
orm has_one relation bug fix

### DIFF
--- a/classes/hasone.php
+++ b/classes/hasone.php
@@ -185,7 +185,7 @@ class HasOne extends Relation {
 		$model_from->_relate($rels);
 		$model_from->freeze();
 
-		if ( ! $model_to->frozen())
+		if ($model_to and ! $model_to->frozen())
 		{
 			foreach ($this->key_to as $fk)
 			{


### PR DESCRIPTION
when i try to delete an object of a model(say model_1) which has a has_one relation with another model(say model_2), and if no one-to-one record for that object of model_1 exists, i get an error:
 "Call to a member function frozen() on a non-object".
In order to fix this, I have modified line 188 to:
if ($model_to and ! $model_to->frozen())
as this first checks whether "$model_to" exists or not and then calls the "frozen()" function.

More detail can be found here: http://fuelphp.com/forums/topics/view/4888
