### PR TITLE
Added support for multiple source properties to Observer_slug

### DIFF
--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -2,12 +2,12 @@
 /**
  * Fuel is a fast, lightweight, community driven PHP5 framework.
  *
- * @package		Fuel
- * @version		1.1
- * @author		Fuel Development Team
- * @license		MIT License
- * @copyright	2010 - 2011 Fuel Development Team
- * @link		http://fuelphp.com
+ * @package    Fuel
+ * @version    1.1
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2011 Fuel Development Team
+ * @link       http://fuelphp.com
  */
 
 namespace Orm;
@@ -16,24 +16,32 @@ class Observer_Slug extends Observer
 {
 
 	/**
-	 * @var string Source property, which is used to create the slug
+	 * @var  mixed  Source property or array of properties, which is/are used to create the slug
 	 */
 	public static $source = 'title';
 	
 	/**
-	 * @var string Slug property
+	 * @var  string  Slug property
 	 */
 	public static $property = 'slug';
 
 	/**
 	 * Creates a unique slug and adds it to the object
 	 *
-	 * @param  Model The object
-	 * @return void
+	 * @param   Model  The object
+	 * @return  void
 	 */
 	public function before_insert(Model $obj)
 	{
-		$slug  = \Inflector::friendly_title($obj->{static::$source}, '-', true);
+		$properties = (array) static::$source;
+		$source;
+		
+		foreach ($properties as $property)
+		{
+			$source .= '-'.$obj->{$property};
+		}
+	
+		$slug  = \Inflector::friendly_title(substr($source, 1), '-', true);
 		$same  = $obj->find()->where(static::$property, 'like', $slug.'%')->get();
 
 		if ( ! empty($same))


### PR DESCRIPTION
Now you can use

``` php
<?php
Orm\Observer_slug::$source = array('name', 'favourite_color');

// Creates a slug like 'george-blue-3'
```

like discussed here: https://github.com/fuel/orm/pull/87#issuecomment-2303133
