### PR TITLE
New data_type 'date' for typ

### DIFF
--- a/classes/observer/typing.php
+++ b/classes/observer/typing.php
@@ -58,6 +58,10 @@ class Observer_Typing {
 			'before' => 'Orm\\Observer_Typing::type_json_encode',
 			'after'  => 'Orm\\Observer_Typing::type_json_decode',
 		),
+		'/^date$/uiD' => array(
+			'before' => 'Orm\\Observer_Typing::type_date_decode',
+			'after'  => 'Orm\\Observer_Typing::type_date_encode',
+		),
 	);
 
 	/**
@@ -304,6 +308,31 @@ class Observer_Typing {
 	public static function type_json_decode($var)
 	{
 		return json_decode($var);
+	}
+	
+	/**
+	 * Return a Fuel Date object on the base of a given format
+	 *
+	 * @param int value
+	 * @param array
+	 * @return \Fuel\Core\Date
+	 */
+	public static function type_date_encode($var, $settings)
+	{
+		$pattern = isset($settings['format']) ? $settings['format'] : 'local';
+		return \Date::create_from_string($var , $pattern);
+	}
+	
+	/**
+	 * Return a formated value of a given Fuel Date object
+	 *
+	 * @param \Fuel\Core\Date
+	 * @return int
+	 */
+	public static function type_date_decode(\Date $var, $settings)
+	{
+		$pattern = isset($settings['format']) ? $settings['format'] : 'local';
+		return $var->format($pattern);
 	}
 }
 

--- a/classes/observer/typing.php
+++ b/classes/observer/typing.php
@@ -15,9 +15,10 @@ namespace Orm;
 // Invalid content exception, thrown when conversion is not possible
 class InvalidContentType extends \UnexpectedValueException {}
 
-class Observer_Typing
-{
+class Observer_Typing {
 
+	public static $date_format = 'mysql';
+	
 	/**
 	 * @var  array  types of events to act on and whether they are pre- or post-database
 	 */
@@ -318,26 +319,25 @@ class Observer_Typing
 	 * @param array
 	 * @return \Fuel\Core\Date
 	 */
-	public static function type_date_encode($var, $settings)
+	public static function type_date_encode($var)
 	{
-		if(!isset($settings['format_model'])) throw new InvalidContentType('Value could not be encoded, no option format_model given.');
-		if(!isset($settings['format_view']))  throw new InvalidContentType('Value could not be encoded, no option format_view given.');
+		if(!$ret = \Date::create_from_string($var, static::$date_format))
+		{
+			throw new InvalidContentType('Input was not recognized by pattern.');
+		}
 		
-		return \Date::create_from_string($var, $settings['format_model'])->format($settings['format_view']);
+		return $ret;
 	}
 	
 	/**
 	 * Return a formated value of a given Fuel Date object
 	 *
 	 * @param \Fuel\Core\Date
-	 * @return int
+	 * @return mixed
 	 */
-	public static function type_date_decode($var, $settings)
+	public static function type_date_decode(\Date $var)
 	{
-		if(!isset($settings['format_model'])) throw new InvalidContentType('Value could not be encoded, no option format_model given.');
-		if(!isset($settings['format_view']))  throw new InvalidContentType('Value could not be encoded, no option format_view given.');
-		
-		return \Date::create_from_string($var, $settings['format_view'])->format($settings['format_model']);
+		return $var->format(static::$date_format);
 	}
 }
 

--- a/classes/observer/typing.php
+++ b/classes/observer/typing.php
@@ -320,8 +320,10 @@ class Observer_Typing
 	 */
 	public static function type_date_encode($var, $settings)
 	{
-		$pattern = isset($settings['format']) ? $settings['format'] : 'local';
-		return \Date::create_from_string($var , $pattern);
+		if(!isset($settings['format_model'])) throw new InvalidContentType('Value could not be encoded, no option format_model given.');
+		if(!isset($settings['format_view']))  throw new InvalidContentType('Value could not be encoded, no option format_view given.');
+		
+		return \Date::create_from_string($var, $settings['format_model'])->format($settings['format_view']);
 	}
 	
 	/**
@@ -330,10 +332,12 @@ class Observer_Typing
 	 * @param \Fuel\Core\Date
 	 * @return int
 	 */
-	public static function type_date_decode(\Date $var, $settings)
+	public static function type_date_decode($var, $settings)
 	{
-		$pattern = isset($settings['format']) ? $settings['format'] : 'local';
-		return $var->format($pattern);
+		if(!isset($settings['format_model'])) throw new InvalidContentType('Value could not be encoded, no option format_model given.');
+		if(!isset($settings['format_view']))  throw new InvalidContentType('Value could not be encoded, no option format_view given.');
+		
+		return \Date::create_from_string($var, $settings['format_view'])->format($settings['format_model']);
 	}
 }
 

--- a/classes/observer/typing.php
+++ b/classes/observer/typing.php
@@ -15,7 +15,8 @@ namespace Orm;
 // Invalid content exception, thrown when conversion is not possible
 class InvalidContentType extends \UnexpectedValueException {}
 
-class Observer_Typing {
+class Observer_Typing
+{
 
 	public static $date_format = 'mysql';
 	
@@ -321,7 +322,7 @@ class Observer_Typing {
 	 */
 	public static function type_date_encode($var)
 	{
-		if(!$ret = \Date::create_from_string($var, static::$date_format))
+		if  ( ! $ret = \Date::create_from_string($var, static::$date_format))
 		{
 			throw new InvalidContentType('Input was not recognized by pattern.');
 		}


### PR DESCRIPTION
I added a new `data_type` `date` for typing. This gives you the possibility to retrieve your date/time related model-fields in a format you choose. It works with the `\Fuel\Date` object for i18n.
This is a short sample of how to use it.

```
class Model_Project extends Orm\Model
{
    protected static $_table_name = 'projects';
    protected static $_primary_key = array('id');

    protected static $_properties = array (

        'id'            => array('data_type' => 'int'),
        'start'         => array('data_type' => 'date', 'format_model' => 'timestamp', 'format_view' => 'us'),
        'end'           => array('data_type' => 'date', 'format_model' => 'timestamp', 'format_view' => 'us')

    );
}
```

You can choose any format which is defined in the `date.php` config file, either in `CORE` or `APP` path. `format_model` defines the pattern on the persistance layer (db), while `format_view` is the pattern of the final represenation on your view.
Have fun, or throw away, if it is not needed :)

Oh, and sorry for the mess. GitHub beginner.
