### PR TITLE
Add support for omitting fields from Fieldsets

### DIFF
--- a/classes/observer/validation.php
+++ b/classes/observer/validation.php
@@ -77,6 +77,10 @@ class Observer_Validation extends Observer
 		$properties = is_object($obj) ? $obj->properties() : $class::properties();
 		foreach ($properties as $p => $settings)
 		{
+			if (isset($settings['form']['include']) and ! $settings['form']['include'])
+			{
+				continue;
+			}
 			if (isset($settings['form']['options']))
 			{
 				foreach ($settings['form']['options'] as $key => $value)


### PR DESCRIPTION
Allows you to specify in a model's `$_properties` whether a field should be included/excluded from Fieldsets/Validation.

Example:

```
protected static $_properties = array(
    'id' => array(
        'data_type' => 'int', 
        'form' => array(
            'include' => false,
        ),
    ), 
);
```

(The default is, of course, to include the field)

Use case being that you usually wouldn't want to display fields like `created_at` or `updated_at` in a form.
