### PR TITLE
Pull request for Issue #124. (Observer registration from OUTSIDE of the Model)

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -415,6 +415,18 @@ class Model implements \ArrayAccess, \Iterator {
 	}
 
 	/**
+	 * Register an observer
+	 *
+	 * @param   string  class name of the observer (including namespace)
+	 * @param   mixed   observer options
+	 * @return  void
+	 */
+	public static function register_observer($class, $options = null)
+	{
+		static::$_observers[] = is_null($options) ? array($class) : array($class => $options);
+	}
+
+	/**
 	 * Find one or more entries
 	 *
 	 * @param   mixed


### PR DESCRIPTION
Original Issue here:

I have a feature request. Currently, you can register an observer by adding something like this to your model:

```
class Model_Comment extends \Orm\Model {

    protected static $_properties = array('id', 'email', 'url', 'content');

    protected static $_table_name = 'comments';

    protected static $_observers = array(
        'example', // will call Observer_Example class for all events
        'Orm\\Observer_CreatedOn' => array('before_insert'), // will only call Orm\Observer_CreatedOn at before_insert event
    );
}
```

But, what I want to do is, register an observer for a model OUTSIDE of the model, not inside the model like in the code shown above.

Something like how the Event class works I guess. Theoretically, I would have to register the observer somewhere like so:

`Model_Comment::register_observer('Observer_Akismet', array('events' => array('before_save')));`
