### PR TITLE
Added method to clear cached stuff

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -105,6 +105,31 @@ class Model implements \ArrayAccess, \Iterator {
 		'has_many'      => 'Orm\\HasMany',
 		'many_many'     => 'Orm\\ManyMany',
 	);
+	
+	public static function clear_cached_table_names()
+	{
+		static::$_table_names_cached = array();
+	}
+
+	public static function clear_cached_properties()
+	{
+		static::$_properties_cached = array();
+	}
+
+	public static function clear_cached_relations()
+	{
+		static::$_relations_cached = array();
+	}
+
+	public static function clear_cached_observers()
+	{
+		static::$_observers_cached = array();
+	}
+
+	public static function clear_cached_objects()
+	{
+		static::$_cached_objects = array();
+	}
 
 	/**
 	 * This method is deprecated...use forge() instead.


### PR DESCRIPTION
I recently encountered a situation where after some heavy db operations..... i tried a json_encode($model->to_array), and got an out-of-memory error. The problem was that the orm had cached a lot of stuff and a json_encode had a huge array to traverse. I added a method to clear cached objects, and cleared cached objects(:P), did a query again, and it worked.

Here I have added some static methods to clear stuff which the orm/model caches ...
