### PR TITLE
Accessing relation on new Model Object bug fix

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -856,7 +856,15 @@ class Model implements \ArrayAccess, \Iterator
 		{
 			if ( ! array_key_exists($property, $this->_data_relations))
 			{
-				$this->_data_relations[$property] = $rel->get($this);
+				if ($this->is_new())
+				{
+					$this->_data_relations[$property] = $rel->singular ? null : array();
+				}
+				else
+				{
+					$this->_data_relations[$property] = $rel->get($this);
+				}
+				
 				$this->_update_original_relations(array($property));
 			}
 			return $this->_data_relations[$property];


### PR DESCRIPTION
Don't bother trying to fetch relations of a model when get is called and the object is new
