### PR TITLE
FIX typing observer. Accept string as a date.

### DIFF
--- a/classes/observer/typing.php
+++ b/classes/observer/typing.php
@@ -335,11 +335,17 @@ class Observer_Typing
 	 * @return  int|string
 	 * @throws  InvalidContentType
 	 */
-	public static function type_time_encode(\Fuel\Core\Date $var, array $settings)
+	public static function type_time_encode($var, array $settings)
 	{
+
+		// if needed, try to convert to \Fuel\Core\Date object
 		if ( ! $var instanceof \Fuel\Core\Date)
 		{
-			throw new InvalidContentType('Value must be an instance of the Date class.');
+			try {
+				$var = \Date::forge($var);
+			} catch (\Exception $e) {
+				throw new InvalidContentType('Conversion to Date object failed. ' . $e->getMessage());
+			}
 		}
 
 		if ($settings['data_type'] == 'time_mysql')


### PR DESCRIPTION
MODEL:

'updated_at' => array(
    'label' => 'Updated At',
    'data_type' => 'time_unix',
)
- TYPING OBSERVER

'Orm\Observer_Typing' => array('before_save', 'after_save', 'after_load'),

Fieldset gets int from the mysql db and displays as date in the form.
But saving doesn't work as currently type_time_encode accepts only Date object - not string from the form.

The patch simply tries to convert supplied $var (if not Date already) to a Date object.
