### PR TITLE
Added where/order_by support for Has Many Relationship - Related to Issue #4

### DIFF
--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -49,10 +49,31 @@ class HasMany extends Relation
 			next($this->key_to);
 		}
 		
+		// check for where conditions
 		foreach (\Arr::get($this->conditions, 'where', array()) as $key => $condition)
 		{
 			!is_array($condition) and $condition = array($key, '=', $condition);
 			$query->where($condition);
+		}
+
+		// check for order_by conditions
+		$order_by_conditions = \Arr::get($this->conditions, 'order_by', array());
+		// check to see how they defined the ordering. per documentation: http://docs.fuelphp.com/packages/orm/relations/intro.html#config
+		if ($order_by_conditions == array_values($order_by_conditions))
+		{
+			// defined by simple array with field names
+			foreach ($order_by_conditions as $field)
+			{
+				$query->order_by($field);
+			}
+		}
+		else
+		{
+			// defined by associative array, field_name => direction
+			foreach ($order_by_conditions as $field => $direction)
+			{
+				$query->order_by($field,$direction);
+			}
 		}
 		
 		return $query->get();

--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -59,20 +59,20 @@ class HasMany extends Relation
 		// check for order_by conditions
 		$order_by_conditions = \Arr::get($this->conditions, 'order_by', array());
 		// check to see how they defined the ordering. per documentation: http://docs.fuelphp.com/packages/orm/relations/intro.html#config
-		if ($order_by_conditions == array_values($order_by_conditions))
-		{
-			// defined by simple array with field names
-			foreach ($order_by_conditions as $field)
-			{
-				$query->order_by($field);
-			}
-		}
-		else
+		if (\Arr::is_assoc($order_by_conditions))
 		{
 			// defined by associative array, field_name => direction
 			foreach ($order_by_conditions as $field => $direction)
 			{
 				$query->order_by($field,$direction);
+			}
+		}
+		else
+		{
+			// defined by simple array with field names
+			foreach ($order_by_conditions as $field)
+			{
+				$query->order_by($field);
 			}
 		}
 		

--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -48,6 +48,13 @@ class HasMany extends Relation
 			$query->where(current($this->key_to), $from->{$key});
 			next($this->key_to);
 		}
+		
+		foreach (\Arr::get($this->conditions, 'where', array()) as $key => $condition)
+		{
+			!is_array($condition) and $condition = array($key, '=', $condition);
+			$query->where($condition);
+		}
+		
 		return $query->get();
 	}
 


### PR DESCRIPTION
I added code to respect the relationship condition definitions, both where and order_by, when related records are being retrieved for has-many relationships. This same idea probably needs to be applied across all relationship types.

I implemented the code according to how the functionality is explained in the documentation: http://docs.fuelphp.com/packages/orm/relations/intro.html#config

Example Usage:

``` php
    protected static $_has_many = array(
        'comments' => array(
            'key_from' => 'id',
            'model_to' => 'Model_Comment',
            'key_to' => 'parent_id',
            'cascade_save' => false,
            'cascade_delete' => false,
            'conditions' => array(
                'where' =>  array(
                    array('model_class','=','Model_Page'),
                ),
                'order_by' => array(
                    'created_at' => 'DESC'
                ),
            ),
        ),
    );
```
