### PR TITLE
Model : initialisation of _original_relations. 

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -720,6 +720,7 @@ class Model implements \ArrayAccess, \Iterator
 		{
 			if (is_array($data))
 			{
+				$this->_original_relations[$rel] = array();
 				foreach ($data as $obj)
 				{
 					$this->_original_relations[$rel][] = $obj ? $obj->implode_pk($obj) : null;


### PR DESCRIPTION
Case: relation multiple with value is empty array

If it does not, in get_diff, for a multiple relation, _original_relations is not set and triggers a warning in in_array
