### PR TITLE
Fixed Model::find_all

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -514,10 +514,10 @@ class Model implements \ArrayAccess, \Iterator
 		}
 
 		// Otherwise, lets find stuff
-		elseif (strpos($method, 'find_') === 0)
+		elseif (preg_match('/^find_(?P<type>all|((all_by_|by_)(?P<fields>[a-z_]+)))$/', $method, $match) === 1)
 		{
-			$find_type = strncmp($method, 'find_all_by_', 12) === 0 ? 'all' : (strncmp($method, 'find_by_', 8) === 0 ? 'first' : false);
-			$fields = $find_type === 'first' ? substr($method, 8) : substr($method, 12);
+			$find_type = strncmp($match['type'], 'all', 3) === 0 ? 'all' : 'first';
+			$fields = isset($match['fields']) ? $match['fields'] : false;
 		}
 
 		// God knows, complain
@@ -528,7 +528,7 @@ class Model implements \ArrayAccess, \Iterator
 
 		$where = $or_where = array();
 
-		if (($and_parts = explode('_and_', $fields)))
+		if ($fields and ($and_parts = explode('_and_', $fields)))
 		{
 			foreach ($and_parts as $and_part)
 			{


### PR DESCRIPTION
The Model wasn't recognizing the method `Model::find_all`, only `Model::find_all_by_field` and `Model::find_by_field`. I used a regular expression to match only these three calls, avoiding calls like `Model::find_anything` or `Model::find_all_world_responses_that_make_no_sense` that wasn't raising exception
