### PR TITLE
BUG: Deprecated Fieldset::repopulate($input) in Orm\Model::set_form_fields($form, $instance = null)

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1441,7 +1441,7 @@ class Model implements \ArrayAccess, \Iterator
 	public static function set_form_fields($form, $instance = null)
 	{
 		Observer_Validation::set_fields($instance instanceof static ? $instance : get_called_class(), $form);
-		$instance and $form->repopulate($instance);
+		$instance and $form->populate($instance, true);
 	}
 
 	/**


### PR DESCRIPTION
I´ve change Fieldset::repopulate($input) by Fieldset::populate($input, true) in order to work with Fuel\Core 1.2 when use the method Fieldset::add_model($model, $input)

Without this change the data is not populated on the Fieldset
