### PR TITLE
Uses "conditions" settings even when not in "related"

### DIFF
--- a/classes/belongsto.php
+++ b/classes/belongsto.php
@@ -54,6 +54,14 @@ class BelongsTo extends Relation
 			$query->where(current($this->key_to), $from->{$key});
 			next($this->key_to);
 		}
+
+		$query->order_by(\Arr::get($this->conditions, 'order_by') ?: \Arr::get($this->conditions, 'order_by', array()));
+		foreach (\Arr::get($this->conditions, 'where', array()) as $key => $condition)
+		{
+			! is_array($condition) and $condition = array($key, '=', $condition);
+			$query->where($condition);
+		}
+		
 		return $query->get_one();
 	}
 

--- a/classes/hasmany.php
+++ b/classes/hasmany.php
@@ -48,6 +48,14 @@ class HasMany extends Relation
 			$query->where(current($this->key_to), $from->{$key});
 			next($this->key_to);
 		}
+
+		$query->order_by(\Arr::get($this->conditions, 'order_by') ?: \Arr::get($this->conditions, 'order_by', array()));
+		foreach (\Arr::get($this->conditions, 'where', array()) as $key => $condition)
+		{
+			! is_array($condition) and $condition = array($key, '=', $condition);
+			$query->where($condition);
+		}
+
 		return $query->get();
 	}
 

--- a/classes/hasone.php
+++ b/classes/hasone.php
@@ -50,6 +50,14 @@ class HasOne extends Relation
 			$query->where(current($this->key_to), $from->{$key});
 			next($this->key_to);
 		}
+
+		$query->order_by(\Arr::get($this->conditions, 'order_by') ?: \Arr::get($this->conditions, 'order_by', array()));
+		foreach (\Arr::get($this->conditions, 'where', array()) as $key => $condition)
+		{
+			! is_array($condition) and $condition = array($key, '=', $condition);
+			$query->where($condition);
+		}
+
 		return $query->get_one();
 	}
 


### PR DESCRIPTION
So now, if I'm not using "related", I can sort result.
