### PR TITLE
is_changed('field') was always returning true

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1343,7 +1343,7 @@ class Model implements \ArrayAccess, \Iterator
 		{
 			if (isset($properties[$p]))
 			{
-				if ((array_key_exists($p, $this->_original) and $this->{$p} !== $this->_original[$p]) or array_key_exists($p, $this->_data))
+				if ((array_key_exists($p, $this->_original) and $this->{$p} !== $this->_original[$p]))
 				{
 					return true;
 				}


### PR DESCRIPTION
Broken here, by a seemingly unrelated commit.

https://github.com/fuel/orm/commit/df62d1115888a81bff822ae9a038d823b9a3fbc2

`is_changed('field')` will always return `true`.

For now I have just removed the code that was added, as it isn't clear what you were trying to achieve.
