### PR TITLE
eav can't get empty values from the database

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -994,7 +994,7 @@ class Model implements \ArrayAccess, \Iterator
 			}
 			return $this->_data_relations[$property];
 		}
-		elseif ($value = $this->_get_eav($property))
+		elseif (($value = $this->_get_eav($property)) !== false)
 		{
 			return $value;
 		}


### PR DESCRIPTION
The ORM will not allow previously defined EAV values to be empty because of a simple boolean evaluation of the values coming from the db.

This became a problem for me when the user could potentially empty an eav value.  The orm will throw an OutOfBoundsException (property not found) if the value is empty (or zero).

This is a more accurate test to see if there is an eav value by checking for false explicitly.  Which should only be seen when the EAV record does not exist

Signed-off-by: Ian Turgeon iturgeon@gmail.com
