### PR TITLE
null can be legit values for a column value

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -976,7 +976,7 @@ class Query
 			foreach ($select as $s)
 			{
 				$f = substr($s[0], strpos($s[0], '.') + 1);
-				if ($obj->{$f} === null and $row[$s[1]] !== null)
+				if ( ! isset($obj->{$f}))
 				{
 					$obj->{$f} = $row[$s[1]];
 				}


### PR DESCRIPTION
We're having an issue where the same record is being fetched twice from the database and the caching mechanism updates the data of the previous object rather than creating a new one.

That's great, but when a column of the previous object was updated with the value 'NULL' (which is correct according to our table schema), it's (wrongly) being replaced it with the 'old' value (fetched from the DB the 2nd time).

It seems rather than checking if the value is null, checking that the key exists is better, since a non-retrieved column should not have a null value, but rather an absence of its key in the $_data array().
