### PR TITLE
Fixed bug about obtaining args in Model_Soft::__callStatic

### DIFF
--- a/classes/model/soft.php
+++ b/classes/model/soft.php
@@ -128,8 +128,8 @@ class Model_Soft extends Model
 		{
 			$temp_args = $args;
 
-			$find_type = count($temp_args) > 0 ? array_pop($temp_args) : 'all';
-			$options = count($temp_args) > 0 ? array_pop($temp_args) : array();
+			$find_type = count($temp_args) > 0 ? array_shift($temp_args) : 'all';
+			$options = count($temp_args) > 0 ? array_shift($temp_args) : array();
 
 			return static::deleted($find_type, $options);
 		}


### PR DESCRIPTION
The following code fails because using `array_pop` to obtain arg. I think using `array_shift` is correct in this case.

``` php
class Model_Something extends Model_Soft { }

// error
Model_Soft::find_deleted('all', array(...));
```

Signed-off-by: Hiroyuki Anai pirosikick@gmail.com
