### PR TITLE
Add the possibility to use Fuel\Core\Cache in order to cache model properties.

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -292,7 +292,7 @@ class Model implements \ArrayAccess, \Iterator
 		{
 			try
 			{
-				$properties = \Cache::get('model_properties.'.$class);
+				$properties = \Cache::get('model_properties.'.str_replace('\\', '_', $class));
 			}
 			catch (\CacheNotFoundException $e) {}
 		}
@@ -303,7 +303,7 @@ class Model implements \ArrayAccess, \Iterator
 			try
 			{
 				$properties = \DB::list_columns(static::table(), null, static::connection());
-				$use_cache_file and \Cache::set('model_properties.'.$class, $properties);
+				$use_cache_file and \Cache::set('model_properties.'.str_replace('\\', '_', $class), $properties);
 			}
 			catch (\Exception $e)
 			{
@@ -1042,7 +1042,7 @@ class Model implements \ArrayAccess, \Iterator
 			if ($reload_cache)
 			{
 				$class = get_called_class();
-				\Cache::delete('model_properties.'.$class);
+				\Cache::delete('model_properties.'.str_replace('\\', '_', $class));
 				unset(static::$_properties_cached[$class]);
 				$reload_cache = false;
 				try

--- a/classes/model.php
+++ b/classes/model.php
@@ -117,6 +117,11 @@ class Model implements \ArrayAccess, \Iterator
 		'many_many'     => 'Orm\\ManyMany',
 	);
 
+	public static function _init()
+	{
+		\Config::load('orm', true);
+	}
+
 	public static function forge($data = array(), $new = true, $view = null)
 	{
 		return new static($data, $new, $view);
@@ -281,12 +286,24 @@ class Model implements \ArrayAccess, \Iterator
 			}
 		}
 
+		// ...if the above failed, look up cache file to fetch properties
+		$use_cache_file = \Config::get('orm.properties_cached', false);
+		if (empty($properties) && $use_cache_file)
+		{
+			try
+			{
+				$properties = \Cache::get('model_properties.'.$class);
+			}
+			catch (\CacheNotFoundException $e) {}
+		}
+
 		// ...if the above failed, run DB query to fetch properties
 		if (empty($properties))
 		{
 			try
 			{
 				$properties = \DB::list_columns(static::table(), null, static::connection());
+				$use_cache_file and \Cache::set('model_properties.'.$class, $properties);
 			}
 			catch (\Exception $e)
 			{
@@ -1015,12 +1032,35 @@ class Model implements \ArrayAccess, \Iterator
 		}
 		elseif (array_key_exists($property, $this->_custom_data))
 		{
-				return $this->_custom_data[$property];
+			return $this->_custom_data[$property];
 		}
-		else
+		// Check if $property is a new column, i.e. if the cache is outdated
+		elseif (\Config::get('orm.properties_cached', false))
 		{
-			throw new \OutOfBoundsException('Property "'.$property.'" not found for '.get_called_class().'.');
+			// Prevent looping
+			static $reload_cache = true;
+			if ($reload_cache)
+			{
+				$class = get_called_class();
+				\Cache::delete('model_properties.'.$class);
+				unset(static::$_properties_cached[$class]);
+				$reload_cache = false;
+				try
+				{
+					// get() calls properties(), i.e. regenerates the cache file
+					$value = $this->get($property);
+					$reload_cache = true;
+					return $value;
+				}
+				catch (\OutOfBoundsException $e)
+				{
+					$reload_cache = true;
+					throw $e;
+				}
+			}
 		}
+
+		throw new \OutOfBoundsException('Property "'.$property.'" not found for '.get_called_class().'.');
 	}
 
 	/**
@@ -1250,10 +1290,10 @@ class Model implements \ArrayAccess, \Iterator
 
 		return true;
 	}
-	
+
 	/**
 	 * Adds the primary keys in where clauses to the given query.
-	 * 
+	 *
 	 * @param Query $query
 	 */
 	protected function add_primary_keys_to_where($query)

--- a/classes/model/temporal.php
+++ b/classes/model/temporal.php
@@ -4,7 +4,7 @@ namespace Orm;
 
 /**
  * Allows revisions of database entries to be kept when updates are made.
- * 
+ *
  * @author Steve "Uru" West <uruwolf@gmail.com>
  */
 class Model_Temporal extends Model
@@ -24,7 +24,7 @@ class Model_Temporal extends Model
 	 * Contains the status of the primary key disable flag for temporal models
 	 */
 	protected static $_pk_check_disabled = array();
-	
+
 	/**
 	 * Contains the status for classes that defines if primaryKey() should return
 	 * just the ID.
@@ -36,21 +36,16 @@ class Model_Temporal extends Model
 	 * to the timestamp used to find the revision.
 	 */
 	protected $_lazy_timestamp = null;
-	
+
 	/**
 	 * Contains the filtering status for temporal queries
 	 */
 	protected static $_lazy_filtered_classes = array();
-	
-	public static function _init()
-	{
-		\Config::load('orm', true);
-	}
 
 	/**
 	 * Gets the temporal properties.
 	 * Mostly stolen from the parent class properties() function
-	 * 
+	 *
 	 * @return array
 	 */
 	public static function temporal_properties()
@@ -110,10 +105,10 @@ class Model_Temporal extends Model
 	}
 
 	/**
-	 * Finds a specific revision for the given ID. If a timestamp is specified 
+	 * Finds a specific revision for the given ID. If a timestamp is specified
 	 * the revision returned will reflect the entity's state at that given time.
 	 * This will also load relations when requested.
-	 * 
+	 *
 	 * @param type $id
 	 * @param int $timestamp Null to get the latest revision (Same as find($id))
 	 * @param array $relations Names of the relations to load.
@@ -128,7 +123,7 @@ class Model_Temporal extends Model
 
 		$timestamp_start_name = static::temporal_property('start_column');
 		$timestamp_end_name = static::temporal_property('end_column');
-		
+
 		//Select the next latest revision after the requested one then use that
 		//to get the revision before.
 		self::disable_primary_key_check();
@@ -141,7 +136,7 @@ class Model_Temporal extends Model
 
 		//Make sure the temporal stuff is activated
 		$query->set_temporal_properties($timestamp, $timestamp_end_name, $timestamp_start_name);
-		
+
 		foreach ($relations as $relation)
 		{
 			$query->related($relation);
@@ -151,16 +146,16 @@ class Model_Temporal extends Model
 		$query_result->set_lazy_timestamp($timestamp);
 		return $query_result;
 	}
-	
+
 	private function set_lazy_timestamp($timestamp)
 	{
 		$this->_lazy_timestamp = $timestamp;
 	}
-	
+
 	/**
 	 * Overrides Model::get() to allow lazy loaded relations to be filtered
 	 * temporaly.
-	 * 
+	 *
 	 * @param string $property
 	 * @return mixed
 	 */
@@ -184,11 +179,11 @@ class Model_Temporal extends Model
 
 		return parent::get($property);
 	}
-	
+
 	/**
 	 * When a timestamp is set any query objects produced by this temporal model
 	 * will behave the same as find_revision()
-	 * 
+	 *
 	 * @param array $timestamp
 	 */
 	private static function make_query_temporal($timestamp)
@@ -196,10 +191,10 @@ class Model_Temporal extends Model
 		$class = get_called_class();
 		static::$_lazy_filtered_classes[$class] = $timestamp;
 	}
-	
+
 	/**
 	 * Overrides Model::query to provide a Temporal_Query
-	 * 
+	 *
 	 * @param array $options
 	 * @return Temporal_Query
 	 */
@@ -207,27 +202,27 @@ class Model_Temporal extends Model
 	{
 		$timestamp_start_name = static::temporal_property('start_column');
 		$timestamp_end_name = static::temporal_property('end_column');
-		
+
 		$query = Temporal_Query::forge(get_called_class(), static::connection(), $options)
 			->set_temporal_properties(null, $timestamp_end_name, $timestamp_start_name);
-		
+
 		//Check if we need to add filtering
 		$class = get_called_class();
 		$timestamp = \Arr::get(static::$_lazy_filtered_classes, $class, null);
-		
+
 		if(! is_null($timestamp) )
 		{
 			$query->where($timestamp_start_name, '<=', $timestamp)
 				->where($timestamp_end_name, '>', $timestamp);
 		}
-		
+
 		return $query;
 	}
-	
+
 	/**
 	 * Returns a list of revisions between the given times with the most recent
 	 * first. This does not load relations.
-	 * 
+	 *
 	 * @param int|string $id
 	 * @param timestamp $earliestTime
 	 * @param timestamp $latestTime
@@ -236,12 +231,12 @@ class Model_Temporal extends Model
 	{
 		$timestamp_start_name = static::temporal_property('start_column');
 		$max_timestamp = static::temporal_property('max_timestamp');
-		
+
 		if ($earliestTime == null)
 		{
 			$earliestTime = 0;
 		}
-		
+
 		if($latestTime == null)
 		{
 			$latestTime = $max_timestamp;
@@ -262,10 +257,10 @@ class Model_Temporal extends Model
 	/**
 	 * Overrides the default find method to allow the latest revision to be found
 	 * by default.
-	 * 
+	 *
 	 * If any new options to find are added the switch statement will have to be
 	 * updated too.
-	 * 
+	 *
 	 * @param type $id
 	 * @param array $options
 	 * @return type
@@ -274,7 +269,7 @@ class Model_Temporal extends Model
 	{
 		$timestamp_end_name = static::temporal_property('end_column');
 		$max_timestamp = static::temporal_property('max_timestamp');
-		
+
 		switch ($id)
 		{
 			case NULL:
@@ -288,21 +283,21 @@ class Model_Temporal extends Model
 				foreach(static::getNonTimestampPks() as $key)
 				{
 					$options['where'][] = array($key, $id[$count]);
-					
+
 					$count++;
 				}
 				break;
 		}
-		
+
 		$options['where'][] = array($timestamp_end_name, $max_timestamp);
 
 		static::enable_id_only_primary_key();
 		$result = parent::find($id, $options);
 		static::disable_id_only_primary_key();
-		
+
 		return $result;
 	}
-	
+
 	/**
 	 * Returns an array of the primary keys that are not related to temporal
 	 * timestamp information.
@@ -311,7 +306,7 @@ class Model_Temporal extends Model
 	{
 		$timestamp_start_name = static::temporal_property('start_column');
 		$timestamp_end_name = static::temporal_property('end_column');
-		
+
 		$pks = array();
 		foreach(parent::primary_key() as $key)
 		{
@@ -320,12 +315,12 @@ class Model_Temporal extends Model
 				$pks[] = $key;
 			}
 		}
-		
+
 		return $pks;
 	}
 
 	/**
-	 * Overrides the save method to allow temporal models to be 
+	 * Overrides the save method to allow temporal models to be
 	 * @param type $cascade
 	 * @param type $use_transaction
 	 * @return type
@@ -341,7 +336,7 @@ class Model_Temporal extends Model
 		$current_timestamp = $mysql_timestamp ?
 			\Date::forge()->format('mysql') :
 			\Date::forge()->get_timestamp();
-		
+
 		//If this is new then just call the parent and let everything happen as normal
 		if ($this->is_new())
 		{
@@ -349,12 +344,12 @@ class Model_Temporal extends Model
 			$this->{$timestamp_start_name} = $current_timestamp;
 			$this->{$timestamp_end_name} = $max_timestamp;
 			static::enable_primary_key_check();
-			
+
 			//Make sure save will populate the PK
 			static::enable_id_only_primary_key();
 			$result = parent::save($cascade, $use_transaction);
 			static::disable_id_only_primary_key();
-			
+
 			return $result;
 		}
 		//If this is an update then set a new PK, save and then insert a new row
@@ -375,7 +370,7 @@ class Model_Temporal extends Model
 				self::enable_primary_key_check();
 
 				parent::save();
-				
+
 				//Construct a copy of this model and save that with a 0 timestamp
 				foreach ($this->primary_key() as $pk)
 				{
@@ -384,48 +379,48 @@ class Model_Temporal extends Model
 						$newModel->{$pk} = $this->{$pk};
 					}
 				}
-				
+
 				static::disable_primary_key_check();
 				$newModel->{$timestamp_start_name} = $current_timestamp;
 				$newModel->{$timestamp_end_name} = $max_timestamp;
 				static::enable_primary_key_check();
-				
+
 				$result = $newModel->save();
-				
+
 				//Make sure $this is repopulated correctly (So Id's are present)
 				foreach($this->properties() as $proptery => $settings)
 				{
 					$this->_data[$proptery] = $newModel->{$proptery};
 				}
-				
+
 				return $result;
 			}
 		}
 
 		return $this;
 	}
-	
+
 	/**
 	 * ALlows an entry to be updated without having to insert a new row.
 	 * This will not record any changed data as a new revision.
-	 * 
+	 *
 	 * Takes the same options as Model::save()
 	 */
 	public function overwrite($cascade = null, $use_transaction = false)
 	{
 		return parent::save($cascade, $use_transaction);
 	}
-	
+
 	/**
 	 * Restores the entity to this state.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function restore()
 	{
 		$timestamp_end_name = static::temporal_property('end_column');
 		$max_timestamp = static::temporal_property('max_timestamp');
-		
+
 		//check to see if there is a currently active row, if so then don't
 		//restore anything.
 		$activeRow = static::find('first', array(
@@ -434,7 +429,7 @@ class Model_Temporal extends Model
 				array($timestamp_end_name, $max_timestamp),
 			),
 		));
-		
+
 		if(is_null($activeRow))
 		{
 			//No active row was found so we are ok to go and restore the this
@@ -446,7 +441,7 @@ class Model_Temporal extends Model
 			$current_timestamp = $mysql_timestamp ?
 				\Date::forge()->format('mysql') :
 				\Date::forge()->get_timestamp();
-			
+
 			//Make sure this is saved as a new entry
 			$this->_is_new = true;
 			//Update timestamps
@@ -456,13 +451,13 @@ class Model_Temporal extends Model
 			//Save
 			$result = parent::save();
 			static::enable_primary_key_check();
-			
+
 			return $result;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Deletes all revisions of this entity permantly.
 	 */
@@ -474,7 +469,7 @@ class Model_Temporal extends Model
 		return $query->where('id', $this->id)
 			->delete();
 	}
-	
+
 	/**
 	 * Overrides update to remove PK checking when performing an update.
 	 */
@@ -483,26 +478,26 @@ class Model_Temporal extends Model
 		static::disable_primary_key_check();
 		$result = parent::update();
 		static::enable_primary_key_check();
-		
+
 		return $result;
 	}
-	
+
 	/**
 	 * Allows correct PKs to be added when performing updates
-	 * 
+	 *
 	 * @param Query $query
 	 */
 	protected function add_primary_keys_to_where($query)
 	{
 		$timestamp_start_name = static::temporal_property('start_column');
 		$timestamp_end_name = static::temporal_property('end_column');
-		
+
 		$primary_key = array(
 			'id',
 			$timestamp_start_name,
 			$timestamp_end_name,
 		);
-		
+
 		foreach ($primary_key as $pk)
 		{
 			$query->where($pk, '=', $this->_original[$pk]);
@@ -517,17 +512,17 @@ class Model_Temporal extends Model
 	{
 		$id_only = static::get_primary_key_id_only_status();
 		$pk_status = static::get_primary_key_status();
-		
+
 		if ($id_only)
 		{
 			return static::getNonTimestampPks();
 		}
-		
+
 		if ($pk_status && ! $id_only)
 		{
 			return static::$_primary_key;
 		}
-		
+
 		return array();
 	}
 
@@ -551,7 +546,7 @@ class Model_Temporal extends Model
 		$current_timestamp = $mysql_timestamp ?
 			\Date::forge()->format('mysql') :
 			\Date::forge()->get_timestamp();
-		
+
 		static::disable_primary_key_check();
 		$this->{$timestamp_end_name} = $current_timestamp;
 		static::enable_primary_key_check();
@@ -576,7 +571,7 @@ class Model_Temporal extends Model
 			}
 		}
 		$this->unfreeze();
-		
+
 		parent::save();
 
 		$this->observe('after_delete');
@@ -586,7 +581,7 @@ class Model_Temporal extends Model
 
 		return $this;
 	}
-	
+
 	/**
 	 * Disables PK checking
 	 */
@@ -613,7 +608,7 @@ class Model_Temporal extends Model
 		$class = get_called_class();
 		return \Arr::get(self::$_pk_check_disabled, $class, true);
 	}
-	
+
 	/**
 	 * Returns true if the PK shoudl only contain the ID. Defaults to false
 	 */
@@ -622,7 +617,7 @@ class Model_Temporal extends Model
 		$class = get_called_class();
 		return \Arr::get(self::$_pk_id_only, $class, false);
 	}
-	
+
 	/**
 	 * Makes all PKs returned
 	 */

--- a/config/orm.php
+++ b/config/orm.php
@@ -2,4 +2,5 @@
 return array(
 	'sql_max_timestamp_mysql' => '2038-01-18 22:14:08',
 	'sql_max_timestamp_unix' => '2147483647',
+	'properties_cached' => true,
 );


### PR DESCRIPTION
Cache is automatically updated when accessing a non-existent cached property.
