### PR TITLE
Added default primary keys to Model_Temporal

### DIFF
--- a/classes/model/temporal.php
+++ b/classes/model/temporal.php
@@ -11,6 +11,11 @@ class Model_Temporal extends Model
 {
 
 	/**
+	 * Compound primary key that includes the start and end times is required
+	 */
+	protected static $_primary_key = array('id', 'temporal_start', 'temporal_end');
+
+	/**
 	 * Override to change default temporal paramaters
 	 */
 	protected static $_temporal = array();


### PR DESCRIPTION
If a Temporal Model does not set the primary keys some very strange behaviors can sneak up on you. 

Given the model has defaults for the names of these columns, I think it would be a good idea to give the model a matching default primary key.

Signed-off-by: Ian Turgeon iturgeon@gmail.com
