### PR TITLE
Eager Loading of non-temporal related models from a temporal model breaks.

### DIFF
--- a/classes/temporal/query.php
+++ b/classes/temporal/query.php
@@ -43,7 +43,7 @@ class Temporal_Query extends Query
 	 */
 	protected function modify_join_result($join_result, $name)
 	{	
-		if( ! is_null($this->timestamp) and is_a($join_result[$name]['model'], '\\Orm\\Model_Temporal'))
+		if( ! is_null($this->timestamp) and is_subclass_of($join_result[$name]['model'], '\Orm\Model_Temporal'))
 		{
 			//Add the needed conditions to allow for temporal-ness
 			$join_result[$name]['where'][] = array($this->timestamp_start_col, '<=', $this->timestamp);

--- a/classes/temporal/query.php
+++ b/classes/temporal/query.php
@@ -43,7 +43,7 @@ class Temporal_Query extends Query
 	 */
 	protected function modify_join_result($join_result, $name)
 	{	
-		if( ! is_null($this->timestamp))
+		if( ! is_null($this->timestamp) and is_a($join_result[$name]['model'], '\\Orm\\Model_Temporal'))
 		{
 			//Add the needed conditions to allow for temporal-ness
 			$join_result[$name]['where'][] = array($this->timestamp_start_col, '<=', $this->timestamp);


### PR DESCRIPTION
The temporal Model's `modify_join_result()` assumes that all joins on related models are also temporal models, adding temporal query options to them.

This checks if the related model is temporal before inserting the temporal query options into the join.

Signed-off-by: Ian Turgeon iturgeon@gmail.com
