### PR TITLE
Propose set() extension about has_many

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1068,7 +1068,7 @@ class Model implements \ArrayAccess, \Iterator
 			{
 				$this->_data[$property] = $value;
 			}
-			elseif ($relation = static::relations($property))
+			elseif (static::relations($property))
 			{
 				$this->is_fetched($property) or $this->_reset_relations[$property] = true;
 
@@ -1115,6 +1115,11 @@ class Model implements \ArrayAccess, \Iterator
 							$this->_data_relations[$property][$key] = $datum;
 						}
 					}
+				}
+				else
+				{
+					// Other relations (belongs_to, has_one, many_many)
+					$this->_data_relations[$property] = $value;
 				}
 			}
 			elseif ( ! $this->_set_eav($property, $value))

--- a/classes/model.php
+++ b/classes/model.php
@@ -1072,7 +1072,7 @@ class Model implements \ArrayAccess, \Iterator
 			{
 				$this->is_fetched($property) or $this->_reset_relations[$property] = true;
 
-				if (is_array($value) and $model_to = \Arr::get(static::$_has_many, $property.'.model_to'))
+				if (is_array($value) and $model_to = \Arr::get(isset(static::$_has_many) ?: array(), $property.'.model_to'))
 				{
 					foreach ($value as $key => $datum)
 					{


### PR DESCRIPTION
Please see https://github.com/hackoh/orm/blob/1.6/model_tests/tests/model.php

This change makes set() method available to set  to a has_many-related property using assoc. 

For example, can receive input names like `comments[][title]`(inserting), `comments[10][title]`(updating)  from the form, the controller can set() simply.

What do you say to this extension?

(I don't know how to implement tests in case of Orm, so this branch does not include that..sorry.)
