### PR TITLE
Fix PhpErrorException undefined index: id 

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1194,6 +1194,7 @@ class Model implements \ArrayAccess, \Iterator
 
 		// update the original properties on creation and cache object for future retrieval in this request
 		$this->_is_new = false;
+		$this->_original = $this->_data;
 		static::$_cached_objects[get_class($this)][static::implode_pk($this)] = $this;
 
 		$this->observe('after_insert');


### PR DESCRIPTION
If you create an "after_insert" observer that manipulates the just-inserted data, the add_primary_keys_to_where() method call will throw an undefined index exception because _original is empty and _is_new is false. Fix by setting _original to _data immediately after insert.
