### PR TITLE
Added Collections to Orm Data Results

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -21,6 +21,7 @@ Autoloader::add_classes(array(
 	'Orm\\HasOne'               => __DIR__.'/classes/hasone.php',
 	'Orm\\ManyMany'             => __DIR__.'/classes/manymany.php',
 	'Orm\\Relation'             => __DIR__.'/classes/relation.php',
+	'Orm\\Collection'             => __DIR__.'/classes/collection.php',
 
 	//Speclised models
 	'Orm\\Model_Soft'           => __DIR__.'/classes/model/soft.php',

--- a/classes/collection.php
+++ b/classes/collection.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Fuel
+ *
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package    Fuel
+ * @version    1.6
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2013 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+namespace Orm;
+
+class Collection extends \ArrayIterator
+{
+	private $_model;
+
+	/**
+	 * forge function.
+	 * 
+	 * @access public
+	 * @static
+	 * @param mixed $model
+	 * @param array $data (default: array())
+	 * @return void
+	 */
+	public static function forge($model,array $data = array()){
+		return new self($model, $data);
+	}
+	
+	/**
+	 * __construct function.
+	 * 
+	 * @access public
+	 * @param array $array (default: array())
+	 * @return void
+	 */
+	public function __construct($model, array $array=array()) {
+		$this->_model = $model;
+		
+		return parent::__construct($array);
+	}
+	
+	/**
+	 * getMode function.
+	 * 
+	 * @access public
+	 * @return void
+	 */
+	public function getMode(){
+		return $this->_model;
+	}
+	
+	public function implode_pk($data){
+		$data = array();
+		
+		foreach($data as $n=>$v){
+			$data[] = $v->implode_pk($v);
+		}
+		
+		return $data;
+	}
+}

--- a/classes/collection.php
+++ b/classes/collection.php
@@ -44,13 +44,47 @@ class Collection extends \ArrayIterator
 		return parent::__construct($array);
 	}
 	
+	
+	/**
+	 * __get function.
+	 * 
+	 * @access public
+	 * @param mixed $name
+	 * @return void
+	 */
+	public function __get($name){
+		
+		$class = get_called_class();
+		$results = new $class($this->get_model());
+		
+		$is_nested = true;
+		
+		foreach ($this as $n=>$v){
+			$results[$n] = $v->{$name};
+			
+			if (!is_subclass_of($v,$class) && get_class($v) != $class) $is_nested = false;
+			
+		}
+		
+		if (count($this) && $is_nested){
+			$_results = array();
+			
+			foreach ($results as $result) $_results = $_results + $result->getArrayCopy();
+			
+			$results = new $class($this->get_model(),$_results);
+		}
+		
+		return $results;
+		
+	}
+	
 	/**
 	 * getMode function.
 	 * 
 	 * @access public
 	 * @return void
 	 */
-	public function get_mode(){
+	public function get_model(){
 		return $this->_model;
 	}
 	

--- a/classes/collection.php
+++ b/classes/collection.php
@@ -5,7 +5,7 @@
  * Fuel is a fast, lightweight, community driven PHP5 framework.
  *
  * @package    Fuel
- * @version    1.6
+ * @version    1.7
  * @author     Fuel Development Team
  * @license    MIT License
  * @copyright  2010 - 2013 Fuel Development Team
@@ -28,7 +28,7 @@ class Collection extends \ArrayIterator
 	 * @return void
 	 */
 	public static function forge($model,array $data = array()){
-		return new self($model, $data);
+		return new static($model, $data);
 	}
 	
 	/**
@@ -50,14 +50,22 @@ class Collection extends \ArrayIterator
 	 * @access public
 	 * @return void
 	 */
-	public function getMode(){
+	public function get_mode(){
 		return $this->_model;
 	}
 	
+	/**
+	 * implode_pk function.
+	 * 
+	 * @access public
+	 * @param mixed $data
+	 * @return void
+	 */
 	public function implode_pk($data){
 		$data = array();
 		
-		foreach($data as $n=>$v){
+		foreach($data as $n=>$v)
+		{
 			$data[] = $v->implode_pk($v);
 		}
 		

--- a/classes/model.php
+++ b/classes/model.php
@@ -118,6 +118,11 @@ class Model implements \ArrayAccess, \Iterator
 		'has_many'      => 'Orm\\HasMany',
 		'many_many'     => 'Orm\\ManyMany',
 	);
+	
+	/**
+	 * @var  string  collection object to be used when fetching an object of this type
+	 */
+	protected static $_collection_class = 'Orm\\Collection';
 
 	public static function forge($data = array(), $new = true, $view = null, $cache = true)
 	{
@@ -427,6 +432,19 @@ class Model implements \ArrayAccess, \Iterator
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get the name of the class that is used for the collection
+	 *
+	 * @param   string
+	 * @return  array
+	 */
+	public static function _collection_class()
+	{
+		
+		return self::$_collection_class;
+
 	}
 
 	/**

--- a/classes/model.php
+++ b/classes/model.php
@@ -122,7 +122,7 @@ class Model implements \ArrayAccess, \Iterator
 	/**
 	 * @var  string  collection object to be used when fetching an object of this type
 	 */
-	protected static $_collection_class = 'Orm\\Collection';
+	// protected static $_collection_class = 'Orm\\Collection';
 
 	public static function forge($data = array(), $new = true, $view = null, $cache = true)
 	{
@@ -442,8 +442,9 @@ class Model implements \ArrayAccess, \Iterator
 	 */
 	public static function _collection_class()
 	{
-		
-		return self::$_collection_class;
+		$class = get_called_class();
+		if (property_exists($class, '_collection_class')) return static::$_collection_class;
+		else return 'Orm\\Collection';
 
 	}
 

--- a/classes/query.php
+++ b/classes/query.php
@@ -1183,9 +1183,12 @@ class Query
 			unset($rows[$id]);
 		}
 		
-		$collectionClass = $model::_collection_class();
-		$result = $collectionClass::forge($model,$result);
+		\Config::load('orm', true);
 		
+		if (\Config::get('orm.use_collections')){
+			$collectionClass = $model::_collection_class();
+			$result = $collectionClass::forge($model,$result);
+		}
 		// It's all built, now lets execute and start hydration
 		return $result;
 	}

--- a/classes/query.php
+++ b/classes/query.php
@@ -1182,7 +1182,10 @@ class Query
 			$this->hydrate($row, $models, $result, $model, $select, $primary_key);
 			unset($rows[$id]);
 		}
-
+		
+		$collectionClass = $model::_collection_class();
+		$result = $collectionClass::forge($model,$result);
+		
 		// It's all built, now lets execute and start hydration
 		return $result;
 	}

--- a/config/orm.php
+++ b/config/orm.php
@@ -2,4 +2,5 @@
 return array(
 	'sql_max_timestamp_mysql' => '2038-01-18 22:14:08',
 	'sql_max_timestamp_unix' => 2147483647,
+	'use_collections' => false
 );


### PR DESCRIPTION
This change is a proof of concept of extendable per-model data collections being set up for any ORM dataset, while still not interfering with existing code.

In short, instead of returning a static array, this would return an object with ArrayAccess enabled on it so that you can still treat it like an array, but each model can custom define a collections model so that one has infinite flexibility on the data that is returned.

I am confident there is a more efficient way of generating these collections, however this will get the ball rolling.

Feel free to contact me with further questions on this.

Thanks,
