### PR TITLE
Fix Nestedset::save() and delete_tree()

### DIFF
--- a/classes/model/nestedset.php
+++ b/classes/model/nestedset.php
@@ -1166,7 +1166,7 @@ class Model_Nestedset extends Model
 				// and delete them to
 				foreach ($children as $child)
 				{
-					if ($child->delete($cascade) === false)
+					if ($child->delete_tree($cascade) === false)
 					{
 						throw new \UnexpectedValueException('delete of child node with PK "'.$child->{$pk}.'" failed.');
 					}

--- a/classes/model/nestedset.php
+++ b/classes/model/nestedset.php
@@ -953,9 +953,10 @@ class Model_Nestedset extends Model
 				// set the left- and right pointers for the new root
 				$this->_data[$left_field] = 1;
 				$this->_data[$right_field] = 2;
+				$pk = reset(static::$_primary_key);
 
 				// we need to check if we don't already have this root
-				$query = \DB::select('id')
+				$query = \DB::select($pk)
 					->from(static::table())
 					->where($left_field, '=', 1);
 


### PR DESCRIPTION
Found the first by accident, when starting to use ORM's Nestedset model. Method `save()` would throw an exception if the model's primary-key isn't set to 'id' but something else (like 'node_id', or whatever).

This commit fixes this bug by changing `\DB::select('id')` to `\DB::select($pk)` where `$pk = reset(static::$_primary_key)`

The second commit fixes incorrect behavior where deleting a tree only cascades down for one level i.e., to descendants of level N+1, but not any further down.
