### PR TITLE
Update Orm\Model::to_object() to allow same parameters as to_array()

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1915,9 +1915,9 @@ class Model implements \ArrayAccess, \Iterator
 	 *
 	 * @return  object
 	 */
-	public function to_object()
+	public function to_object($custom = false, $recurse = false)
 	{
-		return (object) $this->to_array();
+		return (object) $this->to_array($custom, $recurse);
 	}
 
 	/**


### PR DESCRIPTION
I just ran across this case that did not support getting custom properties within a stdClass-object when running `to_object()` on an Orm\Model.

This fix introduces the same arguments `to_object($custom = false, $recurse = false)` as there are for `to_array()`. This allows for getting custom properties into the stdClass object representation of an Orm-object.
