### PR TITLE
Fix bug in Orm\Model_Nestedset where primary-key was accessed as 'id'

### DIFF
--- a/classes/model/nestedset.php
+++ b/classes/model/nestedset.php
@@ -1422,9 +1422,11 @@ class Model_Nestedset extends Model
 				if ( ! $this->is_new())
 				{
 					$parent = $this;
+					$pk = reset(static::$_primary_key);
+					
 					while (($parent = $parent->parent()->get_one()) !== null)
 					{
-						$result[$parent->id] = $parent;
+						$result[$parent->{$pk}] = $parent;
 					}
 				}
 


### PR DESCRIPTION
Line 1427 referenced primary-key named 'id' even though this must not be true for every model configuration i.e., did not support custom primary-keys.
