### PR TITLE
Add or_where case to _parse_where_array()

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -558,7 +558,7 @@ class Query
 			if (is_array($v_w) and ! empty($v_w[0]) and is_string($v_w[0]))
 			{
 				! $v_w[0] instanceof \Database_Expression and strpos($v_w[0], '.') === false and $v_w[0] = $base.$v_w[0];
-				call_user_func_array(array($this, ($k_w === 'or' ? 'or_' : '').'where'), $v_w);
+				call_user_func_array(array($this, ($k_w === 'or' || strpos($k_w, 'or:') === 0 ? 'or_' : '').'where'), $v_w);
 			}
 			elseif (is_int($k_w) or $k_w == 'or')
 			{


### PR DESCRIPTION
This change makes the following forms possible.

``` php
$items = \Model_Item::find('all', array(
    'where' => array(
        array(
            'or:0' => array('title', 'like', '%foo%'),
            'or:1' => array('description', 'like', '%foo%'),
        ),
        array(
            'or:0' => array('title', 'like', '%bar%'),
            'or:1' => array('description', 'like', '%bar%'),
        )
    )
));
```
