### PR TITLE
Fix bug in Orm\Model_Nestedset::dump_tree()

### DIFF
--- a/classes/model/nestedset.php
+++ b/classes/model/nestedset.php
@@ -779,7 +779,7 @@ class Model_Nestedset extends Model
 			$node[$children] = array();
 
 			// is this node a child of the current parent?
-			if ($treenode->{$left_field} > $tracker[$index][$right_field])
+			while ($treenode->{$left_field} > $tracker[$index][$right_field])
 			{
 				// no, so pop the last parent and move a level back up
 				$index--;


### PR DESCRIPTION
Whem node had 2 and more levels of childs, next node on level 0 was child of one level up node in returned array.

Signed-off-by: Kristián Feldsam feldsam@gmail.com
