### PR TITLE
Removed int casting for min/max to allow for dates

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1341,7 +1341,7 @@ class Query
 			return false;
 		}
 
-		return (int) $max;
+		return $max;
 	}
 
 	/**
@@ -1376,7 +1376,7 @@ class Query
 			return false;
 		}
 
-		return (int) $min;
+		return $min;
 	}
 
 	/**


### PR DESCRIPTION
The max and min methods casted the result to an integer before returning - I don't really see a reason for this as the user should be aware of the data type on the database, and casting to an int prevents retrieval of min/max for dates and datetimes. 
