### PR TITLE
Pagination refactor

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1357,7 +1357,10 @@ class Query
 		// Should be already ordered.
 		$values = array_unique($this->values());
 		$total = count($values);
-
+		if(!$total) {
+			return $this;
+		}
+		
 		$config = array(
 			'total_items'    => $total,
 			'current_page'=>$page,
@@ -1417,7 +1420,7 @@ class Query
 			return false;
 		}
 
-		return (int) $max;
+		return $max;
 	}
 
 	/**
@@ -1452,7 +1455,7 @@ class Query
 			return false;
 		}
 
-		return (int) $min;
+		return $min;
 	}
 
 	/**

--- a/classes/query.php
+++ b/classes/query.php
@@ -1407,7 +1407,7 @@ class Query
 			return false;
 		}
 
-		return $max;
+		return (int) $max;
 	}
 
 	/**
@@ -1442,7 +1442,7 @@ class Query
 			return false;
 		}
 
-		return $min;
+		return (int) $min;
 	}
 
 	/**

--- a/classes/query.php
+++ b/classes/query.php
@@ -1323,8 +1323,9 @@ class Query
 	 * and it's much more complicated to add offset and limit. For example, you get the total, get the IDs, apply offset + limit
 	 * with PHP, and then add where('id', 'IN', $ids) to the final query to do "bogus" pagination
 	 * 
-	 * @param  [type] $column [description]
-	 * @return [type]         [description]
+	 * @param  string $column Column to get the value(s) of. Defaults to primary key
+	 * @return array array of values
+	 * @author  Jason Raede <jason.raede@gmail.com>
 	 */
 	public function values($column = null) {
 		$select = $column ?: \Arr::get(call_user_func($this->model.'::primary_key'), 0);
@@ -1343,6 +1344,15 @@ class Query
 		return array_keys($query->execute($this->connection)->as_array($select));
 	}
 
+	/**
+	 * Applies pagination without the use of limit or offset, thus mitigating any issue caused by relations, subqueries, etc
+	 * 	
+	 * @param  int  $per_page   Results to show per page
+	 * @param  integer $page       Current page
+	 * @param  mixed $pagination This can either be an instance of \Fuel\Core\Pagination or just a blank variable passed by reference which will then become the pagination object
+	 * @return $this for chaining
+	 * @author  Jason Raede <jason.raede@gmail.com>
+	 */
 	public function apply_pagination($per_page, $page = 1, &$pagination) {
 		// Should be already ordered.
 		$values = array_unique($this->values());

--- a/classes/query.php
+++ b/classes/query.php
@@ -1357,10 +1357,8 @@ class Query
 		// Should be already ordered.
 		$values = array_unique($this->values());
 		$total = count($values);
-		if(!$total) {
-			return $this;
-		}
 		
+
 		$config = array(
 			'total_items'    => $total,
 			'current_page'=>$page,
@@ -1376,6 +1374,10 @@ class Query
 			foreach($config as $key=>$val) {
 				$pagination->$key = $val;
 			}
+		}
+
+		if(!$total) {
+			return $this;
 		}
 		
 

--- a/classes/query.php
+++ b/classes/query.php
@@ -1341,7 +1341,7 @@ class Query
 			return false;
 		}
 
-		return (int) $max;
+		return $max;
 	}
 
 	/**
@@ -1376,7 +1376,7 @@ class Query
 			return false;
 		}
 
-		return (int) $min;
+		return $min;
 	}
 
 	/**

--- a/classes/query.php
+++ b/classes/query.php
@@ -742,13 +742,14 @@ class Query
 		$where_backup = $this->where;
 		if ( ! empty($this->where))
 		{
+			
 			$open_nests = 0;
 			$where_nested = array();
 			$include_nested = true;
 			foreach ($this->where as $key => $w)
 			{
+				
 				list($method, $conditional) = $w;
-
 				if ($type == 'select' and (empty($conditional) or $open_nests > 0))
 				{
 					$include_nested and $where_nested[$key] = $w;
@@ -773,10 +774,16 @@ class Query
 					call_user_func_array(array($query, $method), $conditional);
 					unset($this->where[$key]);
 				}
+
+				// Look for valid columns inside of a DB expr
+				/*elseif($conditional[0] instanceof \Fuel\Core\Database_Expression) {
+					$columns
+				}*/
 			}
 
 			if ($include_nested and ! empty($where_nested))
 			{
+
 				foreach ($where_nested as $key => $w)
 				{
 					list($method, $conditional) = $w;
@@ -987,6 +994,7 @@ class Query
 		// put omitted where conditions back
 		if ( ! empty($this->where))
 		{
+			\Log::debug('Where not empty!:', var_export($this->where, true));
 			foreach ($this->where as $w)
 			{
 				list($method, $conditional) = $w;
@@ -1308,6 +1316,64 @@ class Query
 		}
 
 		return (int) $count;
+	}
+
+	/**
+	 * This method gets an array of the values of a column for use in pagination where you have filters on related models
+	 * and it's much more complicated to add offset and limit. For example, you get the total, get the IDs, apply offset + limit
+	 * with PHP, and then add where('id', 'IN', $ids) to the final query to do "bogus" pagination
+	 * 
+	 * @param  [type] $column [description]
+	 * @return [type]         [description]
+	 */
+	public function values($column = null) {
+		$select = $column ?: \Arr::get(call_user_func($this->model.'::primary_key'), 0);
+
+
+		$aliased = (strpos($select, '.') === false ? $this->alias.'.'.$select : $select);
+
+		// Remove the current select and
+		$query = \DB::select($aliased);
+
+		// Set from view or table
+		$query->from(array($this->_table(), $this->alias));
+
+		$tmp   = $this->build_query($query, $aliased, 'select');
+		$query = $tmp['query'];
+		return array_keys($query->execute($this->connection)->as_array($select));
+	}
+
+	public function apply_pagination($per_page, $page = 1, &$pagination) {
+		// Should be already ordered.
+		$values = array_unique($this->values());
+		$total = count($values);
+
+		$config = array(
+			'total_items'    => $total,
+			'current_page'=>$page,
+			'per_page'       => $per_page,
+		);
+
+
+		if(!$pagination || !$pagination instanceof \Fuel\Core\Pagination) {
+			$pagination = \Pagination::forge(uniqid(), $config);
+		}
+		else {
+			// Apply the config
+			foreach($config as $key=>$val) {
+				$pagination->$key = $val;
+			}
+		}
+		
+
+
+		$paged_values = array_slice($values, $pagination->offset, $pagination->per_page);
+
+		$primary_key = \Arr::get(call_user_func($this->model.'::primary_key'), 0);
+		$this->where($primary_key, 'IN', $paged_values);
+
+		return $this;
+
 	}
 
 	/**


### PR DESCRIPTION
ORM query pagination has always had issues when adding relations to the mix. This fixes that by avoiding the use of LIMIT and OFFSET, and rather just adding one extra query to retrieve the primary keys of all matching main (first-level) models, and then adding a where condition for {PRIMARY_KEY} IN ($values), where $values is the paginated set of primary key results. 

So basically, no more need for subqueries, it functions the same as \Orm\Query::count() in terms of query generation, and just applies pagination based on the desired position in the full primary key result set.

Example:

```
$query = \Model\Paycheck::query()->related('employee')->related('company')->where('company.city', 'Los Angeles');

// This is optional - if you don't provide an instance of \Fuel\Core\Pagination then the add_pagination method
// will create one on the variable passed by reference to the method (third argument)
$pagination = \Pagination::forge('my-pagination', array(
    'pagination_url'=>'/paycheck/index', 
    'uri_segment'=>'page'
));

$results = $query->order_by('employee.name')->apply_pagination(\Input::get('page', 1), 20, $pagination)->get();
```
