### PR TITLE
Bugfix : hasmany relations correctly hydrated when using from_cache=false

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1068,9 +1068,21 @@ class Query
 			$obj[$pk] = $row[$pk_c];
 		}
 
-		// Check for cached object
+		// Check for already builed object
 		$pk  = count($primary_key) == 1 ? reset($obj) : '['.implode('][', $obj).']';
-		$obj = $this->from_cache ? Model::cached_object($pk, $model) : false;
+		// if the result to be generated is an array and the current object is yet in there
+		if (is_array($result) and array_key_exists($pk, $result))
+		{
+			$obj = $result[$pk];
+		}
+		// if the result to be generated is a single object and not empty, this is the current object
+		elseif ( ! is_array($result) and !empty($result))
+		{
+			$obj = $result;
+		}
+		else {
+			$obj = $this->from_cache ? Model::cached_object($pk, $model) : false;
+		}
 
 		// Create the object when it wasn't found
 		if ( ! $obj)

--- a/classes/query.php
+++ b/classes/query.php
@@ -1068,7 +1068,7 @@ class Query
 			$obj[$pk] = $row[$pk_c];
 		}
 
-		// Check for already builed object
+		// Check for already built object
 		$pk  = count($primary_key) == 1 ? reset($obj) : '['.implode('][', $obj).']';
 		// if the result to be generated is an array and the current object is yet in there
 		if (is_array($result) and array_key_exists($pk, $result))
@@ -1076,7 +1076,7 @@ class Query
 			$obj = $result[$pk];
 		}
 		// if the result to be generated is a single object and not empty, this is the current object
-		elseif ( ! is_array($result) and !empty($result))
+		elseif ( ! is_array($result) and ! empty($result))
 		{
 			$obj = $result;
 		}


### PR DESCRIPTION
Without this commit, each item of results only contains the first related item.

My proposition: in hydrate, try to retrieve object in the current results before trying to retrieve it from cache.
