### PR TITLE
Fix bug in \Orm\Model_Temporal::find_revision() throwing exceptions when...

### DIFF
--- a/classes/model/temporal.php
+++ b/classes/model/temporal.php
@@ -166,7 +166,13 @@ class Model_Temporal extends Model
 		}
 
 		$query_result = $query->get_one();
-		$query_result->set_lazy_timestamp($timestamp);
+		
+		// If the query did not return a result but null, then we cannot call
+		//  set_lazy_timestamp on it without throwing errors
+		if ( $query_result !== null )
+		{
+			$query_result->set_lazy_timestamp($timestamp);
+		}
 		return $query_result;
 	}
 


### PR DESCRIPTION
... no revision was found

This PR fixes exceptions being thrown when no revision can be found on the given model. It resulted from the query result being `null` when nothing was found and then calling `set_lazy_timestamp` on a non-object would throw a according exception.

Signed-off-by: Philipp Tempel phtempel@gmail.com
