### PR TITLE
Adds the ability to include relations when using the UpdatedAt observer

### DIFF
--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -116,7 +116,16 @@ class Observer_UpdatedAt extends Observer
 			return false;
 		}
 
-		// Now we know the relation exists loop through all the models and see if anything has changed
+		$relation_object = $obj->relations($relation);
+
+		// Check if whe have a singular relation
+		if ($relation_object->is_singular())
+		{
+			// If so check that one model
+			return $obj->{$relation}->is_changed();
+		}
+
+		// Else we have an array of related objects so start checking them all
 		foreach ($obj->{$relation} as $related_model)
 		{
 			if ($related_model->is_changed())

--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -83,7 +83,7 @@ class Observer_UpdatedAt extends Observer
 			if ($this->relation_changed($obj, $relation))
 			{
 				$relation_changed = true;
-				continue;
+				break;
 			}
 		}
 
@@ -108,6 +108,12 @@ class Observer_UpdatedAt extends Observer
 		if ($obj->relations($relation) === false)
 		{
 			throw new \InvalidArgumentException('Unknown relation '.$relation);
+		}
+
+		// If the relation is not loaded then ignore it.
+		if ( ! $obj->is_fetched($relation))
+		{
+			return false;
 		}
 
 		// Now we know the relation exists loop through all the models and see if anything has changed

--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -40,6 +40,9 @@ class Observer_UpdatedAt extends Observer
 	 */
 	protected $_property;
 
+	/**
+	 * @var array Names of any relations that should be taken into account when checking if the model has been updated
+	 */
 	protected $_relations;
 
 	/**

--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -84,7 +84,7 @@ class Observer_UpdatedAt extends Observer
 			}
 		}
 
-		if ($obj->is_changed() || $relation_changed)
+		if ($obj->is_changed() or $relation_changed)
 		{
 			$obj->{$this->_property} = $this->_mysql_timestamp ? \Date::time()->format('mysql') : \Date::time()->get_timestamp();
 		}

--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -40,6 +40,8 @@ class Observer_UpdatedAt extends Observer
 	 */
 	protected $_property;
 
+	protected $_relations;
+
 	/**
 	 * Set the properties for this observer instance, based on the parent model's
 	 * configuration or the defined defaults.
@@ -51,6 +53,7 @@ class Observer_UpdatedAt extends Observer
 		$props = $class::observers(get_class($this));
 		$this->_mysql_timestamp  = isset($props['mysql_timestamp']) ? $props['mysql_timestamp'] : static::$mysql_timestamp;
 		$this->_property         = isset($props['property']) ? $props['property'] : static::$property;
+		$this->_relations        = isset($props['relations']) ? $props['relations'] : array();
 	}
 
 	/**
@@ -70,9 +73,49 @@ class Observer_UpdatedAt extends Observer
 	 */
 	public function before_update(Model $obj)
 	{
-		if ($obj->is_changed())
+		// If there are any relations loop through and check if any of them have been changed
+		$relation_changed = false;
+		foreach ( $this->_relations as $relation)
+		{
+			if ($this->relation_changed($obj, $relation))
+			{
+				$relation_changed = true;
+				continue;
+			}
+		}
+
+		if ($obj->is_changed() || $relation_changed)
 		{
 			$obj->{$this->_property} = $this->_mysql_timestamp ? \Date::time()->format('mysql') : \Date::time()->get_timestamp();
 		}
+	}
+
+	/**
+	 * Checks to see if any models in the given relation are changed. This function is lazy so will return true as soon
+	 * as it finds something that has changed.
+	 *
+	 * @param Model  $obj
+	 * @param string $relation
+	 *
+	 * @return bool
+	 */
+	protected function relation_changed(Model $obj, $relation)
+	{
+		// Check that the relation exists
+		if ($obj->relations($relation) === false)
+		{
+			throw new \InvalidArgumentException('Unknown relation '.$relation);
+		}
+
+		// Now we know the relation exists loop through all the models and see if anything has changed
+		foreach ($obj->{$relation} as $related_model)
+		{
+			if ($related_model->is_changed())
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/classes/relation.php
+++ b/classes/relation.php
@@ -153,4 +153,14 @@ abstract class Relation
 
 		return $this->{$property};
 	}
+
+	/**
+	 * Returns true if this relation is a singular relation. Eg, has_one not has_many
+	 *
+	 * @return bool
+	 */
+	public function is_singular()
+	{
+		return $this->singular;
+	}
 }


### PR DESCRIPTION
Putting this up here to get thoughts on the feature/implementation. I thought this would be a useful feature as often an ORM entity consists of multiple models.

My example is that a blog post has many "i18ns", translatable data stored in a separate table (so another model), when any of the i18ns are updated I want to be able to reflect that change on the parent blog post. This observer will allow this to work.

``` php
$blog_post->i18ns[$i18n_id]->title = 'My new title';
$blog_post->save();
// $blog_post->updated_at is now "now()"
```

The added setting is used like this:

``` php
protected static $_observers = array(
    'Orm\\Observer_UpdatedAt' => array(
        'events' => array('before_save'),
        'mysql_timestamp' => true,
        'property' => 'updated',
        'relations' => array(
                'i18ns',
        ),
    ),
);
```

Docs are on the way.
