### PR TITLE
Orm\Query::get_query() fixed ignore model connection setting

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1238,7 +1238,7 @@ class Query
 		// Build the query further
 		$tmp     = $this->build_query($query, $columns);
 
-		return $tmp['query'];
+		return $tmp['query']->compile($this->connection);
 	}
 
 	/**


### PR DESCRIPTION
This was issue, if defined connection has different table preffix that default connection.

Signed-off-by: Kristián Feldsam feldsam@gmail.com
