### PR TITLE
1.8/develop

### DIFF
--- a/classes/model/temporal.php
+++ b/classes/model/temporal.php
@@ -245,7 +245,7 @@ class Model_Temporal extends Model
 			$query->where($timestamp_start_name, '<=', $timestamp)
 				->where($timestamp_end_name, '>', $timestamp);
 		}
-		elseif(static::get_primary_key_status())
+		elseif(static::get_primary_key_status() and ! static::get_primary_key_id_only_status())
 		{
 			$query->where($timestamp_end_name, $max_timestamp);
 		}

--- a/classes/model/temporal.php
+++ b/classes/model/temporal.php
@@ -245,7 +245,7 @@ class Model_Temporal extends Model
 			$query->where($timestamp_start_name, '<=', $timestamp)
 				->where($timestamp_end_name, '>', $timestamp);
 		}
-		else
+		elseif(static::get_primary_key_status())
 		{
 			$query->where($timestamp_end_name, $max_timestamp);
 		}


### PR DESCRIPTION
Query is called by find methods, which put the condition in the query. I think those functions limit the primary key check, so the temporal condition is added depending on primary key checking.
