### PR TITLE
Only update original relations with imploded PKs of not new objects

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -892,15 +892,19 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 				$this->_original_relations[$rel] = array();
 				foreach ($data as $obj)
 				{
-					if (! $obj->is_new())
+					if ($obj and ! $obj->is_new())
 					{
-						$this->_original_relations[$rel][] = $obj ? $obj->implode_pk($obj) : null;
+						$this->_original_relations[$rel][] = $obj->implode_pk($obj);
 					}
 				}
 			}
 			else
 			{
-				$this->_original_relations[$rel] = $data ? $data->implode_pk($data) : null;
+				$this->_original_relations[$rel] = null;
+				if ($data and ! $data->is_new())
+				{
+					$this->_original_relations[$rel] = $data->implode_pk($data);
+				}
 			}
 		}
 	}

--- a/classes/model.php
+++ b/classes/model.php
@@ -892,7 +892,10 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 				$this->_original_relations[$rel] = array();
 				foreach ($data as $obj)
 				{
-					$this->_original_relations[$rel][] = $obj ? $obj->implode_pk($obj) : null;
+					if (! $obj->is_new())
+					{
+						$this->_original_relations[$rel][] = $obj ? $obj->implode_pk($obj) : null;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Fixes https://github.com/fuel/orm/issues/327

Setting a relation to an array of new objects without IDs then running some code that hydrates a model or somehow calls _update_original_relations() on the original object and the non-existent IDs get put into the $_original_relations array.
