### PR TITLE
fixed many-to-many relation not using write connection

### DIFF
--- a/classes/manymany.php
+++ b/classes/manymany.php
@@ -278,7 +278,7 @@ class ManyMany extends Relation
 					next($this->key_to);
 				}
 
-				\DB::insert($this->table_through)->set($ids)->execute(call_user_func(array($model_from, 'connection')));
+				\DB::insert($this->table_through)->set($ids)->execute(call_user_func(array($model_from, 'connection'), true));
 				$original_model_ids[] = $current_model_id; // prevents inserting it a second time
 			}
 			else
@@ -322,7 +322,7 @@ class ManyMany extends Relation
 				next($to_keys);
 			}
 
-			$query->execute(call_user_func(array($model_from, 'connection')));
+			$query->execute(call_user_func(array($model_from, 'connection'), true));
 		}
 
 		$cascade = is_null($cascade) ? $this->cascade_save : (bool) $cascade;
@@ -372,6 +372,6 @@ class ManyMany extends Relation
 			$query->where($key, '=', $model_from->{current($this->key_from)});
 			next($this->key_from);
 		}
-		$query->execute(call_user_func(array($model_from, 'connection')));
+		$query->execute(call_user_func(array($model_from, 'connection'), true));
 	}
 }


### PR DESCRIPTION
This already cost us some problems with replication =(

There are also `Orm\Model::connection()` calls in the `join()` method of each relation, but I'm not sure if they should be fixed too (seems like they're only used with SELECT queries).
