### PR TITLE
FEATURE: select custom sql columns

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -796,9 +796,9 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 			$new = false;
 		}
 
+		$properties = $this->properties();
 		if ($new)
 		{
-			$properties = $this->properties();
 			foreach ($properties as $prop => $settings)
 			{
 				if (array_key_exists($prop, $data))
@@ -816,7 +816,14 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		else
 		{
 			$this->_update_original($data);
-			$this->_data = array_merge($this->_data, $data);
+			$obj = array();
+			foreach ($properties as $prop => $settings)
+			{
+				$obj[$prop] = $data[$prop];
+				unset($data[$prop]);
+			}
+			$this->_data = array_merge($this->_data, $obj);
+			$this->_custom_data = $data;
 
 			if ($view and array_key_exists($view, $this->views()))
 			{


### PR DESCRIPTION
A new `Query` method `custom()` , which adds extra columns to select. Resulting model will have propertes for those columns.

Example:

``` php
// assume Model_Person has properties 'firstname' and 'sirname' but not 'fullname'.
$query = Model_Person::query();
$query->custom(array('fullname' => DB::expr('CONCAT(firstname,\' \',sirname)')));
$people = $query->get();
foreach($people as $id => $person)
{
    echo $person->fullname;
}
```

Adding columns in such way would be useful, for example:
- relevance score for full-text search
- row numbers for a table
- and other expressions better to calculate on database server
