### PR TITLE
Don't use a frozen object from cache when hydrating

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1073,7 +1073,7 @@ class Query
 		$obj = $this->from_cache ? Model::cached_object($pk, $model) : false;
 
 		// Create the object when it wasn't found
-		if ( ! $obj)
+		if ( ! $obj or $obj->frozen())
 		{
 			// Retrieve the object array from the row
 			$obj = array();


### PR DESCRIPTION
`Model_Site` belongs to `Model_IP` and `Model_IP` has many `Model_Site`

`Model_IP` has an `Observer_Self` on `after_save` which accesses its `sites` relation and loops over them to use the data for indexing into Elastic Search (no data is modified, only read).

However, when you save a `Model_Site` this cascades to `Model_IP` through its `ip` relation and when `Model_IP`s observer fires it throws a `FrozenObject` exception on lazily loading `Model_IP`'s `sites` relation because the `Model_Site` which the save has cascaded from is frozen.

The reason for a frozen object being retrieved when a relation is lazily loaded is that Orm will retrieve objects from its internal cache when it can. The change in the PR stops this cached object being used if it is frozen.

I am not sure as to what the consequences of not using the cached object might be in this (or any other) situation.
