### PR TITLE
Detailing available options in model and query doc blocks.

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -524,7 +524,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
      * Find one or more entries
      *
      * @param int|null $id
-     * @param array $options
+     * @param array $options - keys include: select, related, use_view, or_where, where, order_by, group_by, limit, offset, rows_limit, rows_offset, from_cache
      *
      * @throws \FuelException
      *

--- a/classes/query.php
+++ b/classes/query.php
@@ -24,7 +24,7 @@ class Query
 	 *
 	 * @param	string  $model      name of the model this instance has to operate on
 	 * @param	mixed   $connection DB connection to use to run the query
-	 * @param	array   $options    any options to pass on to the query
+	 * @param	array   $options    any options to pass on to the query. Keys include: select, related, use_view, or_where, where, order_by, group_by, limit, offset, rows_limit, rows_offset, from_cache
 	 *
 	 * @return	Query	newly created instance
 	 */
@@ -128,7 +128,7 @@ class Query
 	 *
 	 * @param	string  $model        Name of the model this instance has to operate on
 	 * @param	mixed   $connection   DB connection to use to run the query
-	 * @param	array   $options      Any options to pass on to the query
+	 * @param	array   $options      Any options to pass on to the query. Keys include: select, related, use_view, or_where, where, order_by, group_by, limit, offset, rows_limit, rows_offset, from_cache
 	 * @param	mixed   $table_alias  Optionally, the alias to use for the models table
 	 */
 	protected function __construct($model, $connection, $options, $table_alias = null)


### PR DESCRIPTION
Added options keys to documentation for model and query to make them more available in documentation. This came from my hunt to find out there was a from_cache option.
