### PR TITLE
Loose check for all int types in Model::is_changed()

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1672,7 +1672,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 			{
 				if (array_key_exists($p, $this->_original))
 				{
-					if (array_key_exists('data_type', $properties[$p]) and $properties[$p]['data_type'] == 'int')
+					if (array_key_exists('type', $properties[$p]) and $properties[$p]['type'] == 'int')
 					{
 						if ($this->{$p} != $this->_original[$p])
 						{


### PR DESCRIPTION
Actual code works well when `data_type` is `int`, but does not take into account `tinyint` or `mediumint` or `int unsigned`.

The `type` key from the `$properties` always contain `int` in all this situations.

If this is the correct change, we should also change the doc, which doesn't include the `type` key in the examples.
