### PR TITLE
Update slug.php Observer. Uniqueness as option

### DIFF
--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -34,10 +34,10 @@ class Observer_Slug extends Observer
 	 */
 	public static $separator = '-';
 
-    /**
-     * @var  bool  Required to be unique
-     */
-    public static $unique = true;
+ 	/**
+	* @var  bool  Required to be unique
+ 	*/
+	public static $unique = true;
 
 	/**
 	 * @var  mixed  Source property or array of properties, which is/are used to create the slug
@@ -54,10 +54,10 @@ class Observer_Slug extends Observer
 	 */
 	protected $_separator;
 
-    /**
-     * @var  bool  If the slug is required to be unique
-     */
-    protected $_unique;
+ 	/**
+	* @var  bool  If the slug is required to be unique
+ 	*/
+ 	protected $_unique;
 
 	/**
 	 * Set the properties for this observer instance, based on the parent model's
@@ -71,7 +71,7 @@ class Observer_Slug extends Observer
 		$this->_source    = isset($props['source']) ? $props['source'] : static::$source;
 		$this->_property  = isset($props['property']) ? $props['property'] : static::$property;
 		$this->_separator = isset($props['separator']) ? $props['separator'] : static::$separator;
-        $this->_unique    = isset($props['unique']) ? $props['unique'] : static::$unique;
+        	$this->_unique    = isset($props['unique']) ? (bool)$props['unique'] : static::$unique;
 	}
 
 	/**
@@ -91,7 +91,7 @@ class Observer_Slug extends Observer
 		$slug = \Inflector::friendly_title(substr($source, 1), $this->_separator, true);
 
 
-        if($this->_unique == true)
+	if($this->_unique === true)
         {
             // query to check for existence of this slug
             $query = $obj->query()->where($this->_property, 'like', $slug.'%');

--- a/classes/observer/slug.php
+++ b/classes/observer/slug.php
@@ -34,6 +34,11 @@ class Observer_Slug extends Observer
 	 */
 	public static $separator = '-';
 
+    /**
+     * @var  bool  Required to be unique
+     */
+    public static $unique = true;
+
 	/**
 	 * @var  mixed  Source property or array of properties, which is/are used to create the slug
 	 */
@@ -49,6 +54,11 @@ class Observer_Slug extends Observer
 	 */
 	protected $_separator;
 
+    /**
+     * @var  bool  If the slug is required to be unique
+     */
+    protected $_unique;
+
 	/**
 	 * Set the properties for this observer instance, based on the parent model's
 	 * configuration or the defined defaults.
@@ -61,10 +71,11 @@ class Observer_Slug extends Observer
 		$this->_source    = isset($props['source']) ? $props['source'] : static::$source;
 		$this->_property  = isset($props['property']) ? $props['property'] : static::$property;
 		$this->_separator = isset($props['separator']) ? $props['separator'] : static::$separator;
+        $this->_unique    = isset($props['unique']) ? $props['unique'] : static::$unique;
 	}
 
 	/**
-	 * Creates a unique slug and adds it to the object
+	 * Creates a slug (unique by default) and adds it to the object
 	 *
 	 * @param  Model  Model object subject of this observer method
 	 */
@@ -79,46 +90,50 @@ class Observer_Slug extends Observer
 		}
 		$slug = \Inflector::friendly_title(substr($source, 1), $this->_separator, true);
 
-		// query to check for existence of this slug
-		$query = $obj->query()->where($this->_property, 'like', $slug.'%');
 
-		// is this a temporal model?
-		if ($obj instanceOf Model_Temporal)
-		{
-			// add a filter to only check current revisions excluding the current object
-			$class = get_class($obj);
-			$query->where($class::temporal_property('end_column'), '=', $class::temporal_property('max_timestamp'));
-			foreach($class::getNonTimestampPks() as $key)
-			{
-				$query->where($key, '!=', $obj->{$key});
-			}
-		}
+        if($this->_unique == true)
+        {
+            // query to check for existence of this slug
+            $query = $obj->query()->where($this->_property, 'like', $slug.'%');
 
-		// do we have records with this slug?
-		$same = $query->get();
+            // is this a temporal model?
+            if ($obj instanceOf Model_Temporal)
+            {
+                // add a filter to only check current revisions excluding the current object
+                $class = get_class($obj);
+                $query->where($class::temporal_property('end_column'), '=', $class::temporal_property('max_timestamp'));
+                foreach($class::getNonTimestampPks() as $key)
+                {
+                    $query->where($key, '!=', $obj->{$key});
+                }
+            }
 
-		// make sure our slug is unique
-		if ( ! empty($same))
-		{
-			$max = -1;
+            // do we have records with this slug?
+            $same = $query->get();
 
-			foreach ($same as $record)
-			{
-				if (preg_match('/^'.$slug.'(?:'.preg_quote($this->_separator).'([0-9]+))?$/', $record->{$this->_property}, $matches))
-				{
-					$index = isset($matches[1]) ? (int) $matches[1] : 0;
-					$max < $index and $max = $index;
-				}
-			}
+            // make sure our slug is unique
+            if ( ! empty($same))
+            {
+                $max = -1;
 
-			$max < 0 or $slug .= $this->_separator.($max + 1);
-		}
+                foreach ($same as $record)
+                {
+                    if (preg_match('/^'.$slug.'(?:-([0-9]+))?$/', $record->{$this->_property}, $matches))
+                    {
+                        $index = isset($matches[1]) ? (int) $matches[1] : 0;
+                        $max < $index and $max = $index;
+                    }
+                }
+
+                $max < 0 or $slug .= $this->_separator.($max + 1);
+            }
+        }
 
 		$obj->{$this->_property} = $slug;
 	}
 
 	/**
-	 * Creates a new unique slug and update the object
+	 * Creates a new slug (unique by default) and update the object
 	 *
 	 * @param  Model  Model object subject of this observer method
 	 */


### PR DESCRIPTION
I use slugs very often simply to give the end use a better description of the URL and for SEO.

Ex.  "http://server.com/doc/281/communications/about/about-the-communications-department/"

In a case like this I would prefer not to have uniqueness in the slug as I only require the ID (281) and I dislike slugs with numbers in them (about, about-1, about-2) since many "departments" in this case will have an "About" page.
