### PR TITLE
Don't complain about changing PK if it's not actually changing

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1204,7 +1204,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 				throw new \InvalidArgumentException('You need to pass both a property name and a value to set().');
 			}
 
-			if (in_array($property, static::primary_key()) and $this->{$property} !== null)
+			if (in_array($property, static::primary_key()) and $this->{$property} !== null and $this->{$property} != $value)
 			{
 				throw new \FuelException('Primary key on model '.get_class($this).' cannot be changed.');
 			}


### PR DESCRIPTION
This silences "Primary key on model $model cannot be changed." when ORM itself tries to set this value as the result of a relation.

Yes I know this is bad design but it's breaking a legacy system, and legacy is diplomacy speak for badly-designed.
