### PR TITLE
Passing model properties to is_changed method.

### DIFF
--- a/classes/observer/updatedat.php
+++ b/classes/observer/updatedat.php
@@ -87,7 +87,10 @@ class Observer_UpdatedAt extends Observer
 			}
 		}
 
-		if ($obj->is_changed() or $relation_changed)
+		$objClassName = get_class($obj);
+		$objProperties = $objClassName::properties();
+
+		if ($obj->is_changed(array_keys($objProperties)) or $relation_changed)
 		{
 			$obj->{$this->_property} = $this->_mysql_timestamp ? \Date::time()->format('mysql') : \Date::time()->get_timestamp();
 		}


### PR DESCRIPTION
The model method is_changed() also checks all relations by default. The UpdatedAt observer has a property which allows you to update the model update field if any relations also update. 

However if you don't have this filed, the update field is still updated on relation changes. The below commit resolves this by passing the properties to check which will restrict checking to only the model itself then if any relations are need to be check the second part of the observer will handle this.
