### PR TITLE
In "count" queries, do not add all the columns from relations.

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -728,7 +728,7 @@ class Query
 	 *
 	 * @param   \Fuel\Core\Database_Query_Builder_Where  DB where() query object
 	 * @param   array $columns  Optionally
-	 * @param   string $type    Type of query to build (select/update/delete/insert)
+	 * @param   string $type    Type of query to build (count/select/update/delete/insert)
 	 *
 	 * @throws \FuelException            Models cannot be related between different database connections
 	 * @throws \UnexpectedValueException Trying to get the relation of an unloaded relation
@@ -737,6 +737,8 @@ class Query
 	 */
 	public function build_query(\Fuel\Core\Database_Query_Builder_Where $query, $columns = array(), $type = 'select')
 	{
+		$read_query = in_array($type, array('select', 'count'));
+		
 		// Get the limit
 		if ( ! is_null($this->limit))
 		{
@@ -762,7 +764,7 @@ class Query
 			{
 				list($method, $conditional) = $w;
 
-				if ($type == 'select' and (empty($conditional) or $open_nests > 0))
+				if ($read_query and (empty($conditional) or $open_nests > 0))
 				{
 					$include_nested and $where_nested[$key] = $w;
 					if ( ! empty($conditional) and strpos($conditional[0], $this->alias.'.') !== 0)
@@ -776,9 +778,9 @@ class Query
 
 				if (empty($conditional)
 					or strpos($conditional[0], $this->alias.'.') === 0
-					or ($type != 'select' and $conditional[0] instanceof \Fuel\Core\Database_Expression))
+					or (!$read_query and $conditional[0] instanceof \Fuel\Core\Database_Expression))
 				{
-					if ($type != 'select' and ! empty($conditional)
+					if (!$read_query and ! empty($conditional)
 						and ! $conditional[0] instanceof \Fuel\Core\Database_Expression)
 					{
 						$conditional[0] = substr($conditional[0], strlen($this->alias.'.'));
@@ -796,9 +798,9 @@ class Query
 
 					if (empty($conditional)
 						or strpos($conditional[0], $this->alias.'.') === 0
-						or ($type != 'select' and $conditional[0] instanceof \Fuel\Core\Database_Expression))
+						or (!$read_query and $conditional[0] instanceof \Fuel\Core\Database_Expression))
 					{
-						if ($type != 'select' and ! empty($conditional)
+						if (!$read_query and ! empty($conditional)
 							and ! $conditional[0] instanceof \Fuel\Core\Database_Expression)
 						{
 							$conditional[0] = substr($conditional[0], strlen($this->alias.'.'));
@@ -810,8 +812,8 @@ class Query
 			}
 		}
 
-		// If it's not a select we're done
-		if ($type != 'select')
+		// If it's not a select or count, we're done
+		if (!$read_query)
 		{
 			return array('query' => $query, 'models' => array());
 		}
@@ -844,12 +846,16 @@ class Query
 
 		if ($this->use_subquery())
 		{
-			// Get the columns for final select
-			foreach ($models as $m)
+			// Count queries should not select on anything besides the count
+			if ($type != 'count')
 			{
-				foreach ($m['columns'] as $c)
+				// Get the columns for final select
+				foreach ($models as $m)
 				{
-					$columns[] = $c;
+					foreach ($m['columns'] as $c)
+					{
+						$columns[] = $c;
+					}
 				}
 			}
 
@@ -861,7 +867,7 @@ class Query
 					if (strpos($ob[0], $this->alias.'.') === 0)
 					{
 						// order by on the current model
-						$type == 'select' or $ob[0] = substr($ob[0], strlen($this->alias.'.'));
+						$read_query or $ob[0] = substr($ob[0], strlen($this->alias.'.'));
 						$query->order_by($ob[0], $ob[1]);
 					}
 				}
@@ -873,12 +879,16 @@ class Query
 		}
 		else
 		{
-			// add additional selected columns
-			foreach ($models as $m)
+			// Count queries should not select on anything besides the count
+			if ($type != 'count')
 			{
-				foreach ($m['columns'] as $c)
+				// add additional selected columns
+				foreach ($models as $m)
 				{
-					$query->select($c);
+					foreach ($m['columns'] as $c)
+					{
+						$query->select($c);
+					}
 				}
 			}
 		}
@@ -894,8 +904,8 @@ class Query
 		}
 		foreach ($models as $m)
 		{
-			if (($type == 'select' and $m['connection'] != $this->connection) or
-				($type != 'select' and $m['connection'] != $this->write_connection))
+			if (($read_query and $m['connection'] != $this->connection) or
+				(!$read_query and $m['connection'] != $this->write_connection))
 			{
 				throw new \FuelException('Models cannot be related between different database connections.');
 			}
@@ -951,7 +961,7 @@ class Query
 					if (strpos($ob[0], $this->alias.'.') === 0)
 					{
 						// order by on the current model
-						$type == 'select' or $ob[0] = substr($ob[0], strlen($this->alias.'.'));
+						$read_query or $ob[0] = substr($ob[0], strlen($this->alias.'.'));
 					}
 					else
 					{
@@ -1330,7 +1340,7 @@ class Query
 		// Set from view or table
 		$query->from(array($this->_table(), $this->alias));
 
-		$tmp   = $this->build_query($query, $columns, 'select');
+		$tmp   = $this->build_query($query, $columns, 'count');
 		$query = $tmp['query'];
 		$count = $query->execute($this->connection)->get('count_result');
 


### PR DESCRIPTION
Same as https://github.com/fuel/orm/pull/352, but cherry-picked into 1.8:

This can make the difference between using no indexes and writing to disk for a
temp table and bringing down the system versus using indexes and completing in
a few milliseconds.

The comment "// Remove the current select and" seems to imply that this was the
original idea, but maybe the API somehow got changed which caused a performance
regression without anyone noticing it.
