### PR TITLE
Fix on to_array with multi level relations

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -2064,6 +2064,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 					{
 						static::$to_array_references[] = get_class($rel);
 						$array[$name] = $rel->to_array($custom, true, $eav);
+						array_pop(static::$to_array_references);
 					}
 				}
 			}

--- a/classes/model.php
+++ b/classes/model.php
@@ -2045,10 +2045,14 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 				$array[$name] = array();
 				if ( ! empty($rel))
 				{
-					static::$to_array_references[] = get_class(reset($rel));
-					foreach ($rel as $id => $r)
+					if ( ! in_array(get_class(reset($rel)), static::$to_array_references))
 					{
-						$array[$name][$id] = $r->to_array($custom, true, $eav);
+						static::$to_array_references[] = get_class(reset($rel));
+						foreach ($rel as $id => $r)
+						{
+							$array[$name][$id] = $r->to_array($custom, true, $eav);
+							array_pop(static::$to_array_references);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**First, I fixed a problem in to_array method when having _has_many_ relation with a target class having a _has_one_ relation.**

When having relations like 

```
School  -has_many-> School_Class_1 -has_one-> School_Class_1_Info
                    School_Class_2 -has_one-> School_Class_2_Info
                    School_Class_3 -has_one-> School_Class_3_Info
```

The to_array method only inject the first instance of School_Class_Info.
So I get array like

```
school => array(
    ...
    school_class_1 => array(
        ...
        school_class_1_info => array(...)
    ),
    school_class_2 => array(...), // Without school_class_2_info
    school_class_3 => array(...), // Without school_class_3_info
)
```

**In a second commit, I add circular reference check on _has_many_ relation**

Logically this case should not happen with a good data model, but if we want to check circular references, we need to do it in all cases.
