### PR TITLE
Temporal correction for multiple primary keys

### DIFF
--- a/classes/model/temporal.php
+++ b/classes/model/temporal.php
@@ -133,16 +133,29 @@ class Model_Temporal extends Model
 	 *
 	 * @param type $id
 	 * @param int $timestamp Null to get the latest revision (Same as find($id))
+     * @param array $relations Names of the relations to load.
      * @param array $options Options to load.
 	 * @return Subclass of Orm\Model_Temporal
 	 */
-	public static function find_revision($id, $timestamp = null, $options = array())
+	public static function find_revision($id, $timestamp = null, $relations = array(), $options = array())
 	{
 		if ($timestamp == null)
 		{
 			return parent::find($id, $options);
 		}
 
+        if (!empty($relations))
+        {
+            if (isset($options['related']))
+            {
+                $options['related'] = \Arr::merge($options['related'], $relations);
+            }
+            else
+            {
+                $options['related'] = $relations;
+            }
+        }
+        
 		$timestamp_start_name = static::temporal_property('start_column');
 		$timestamp_end_name = static::temporal_property('end_column');
 
@@ -152,18 +165,18 @@ class Model_Temporal extends Model
 
 		$query = static::query($options);
 
-        $pk = static::getNonTimestampPks();
+        $pks = static::getNonTimestampPks();
         
-        if (count($pk) > 1)
+        if (count($pks) > 1)
         {
-		    foreach($pk as $index => $key)
+		    foreach($pks as $index => $key)
 		    {
                 $query->where($key, $id[$index]);
 		    }
         }
         else
         {
-            $query->where('id', $id);
+            $query->where($pks[0], $id);
         }
         
         $query
@@ -291,18 +304,18 @@ class Model_Temporal extends Model
 		//Select all revisions within the given range.
 		$query = static::query($options);
 
-        $pk = static::getNonTimestampPks();
+        $pks = static::getNonTimestampPks();
         
-        if (count($pk) > 1)
+        if (count($pks) > 1)
         {
-		    foreach($pk as $index => $key)
+		    foreach($pks as $index => $key)
 		    {
                 $query->where($key, $id[$index]);
 		    }
         }
         else
         {
-            $query->where('id', $id);
+            $query->where($pks[0], $id);
         }
         
         $query
@@ -495,18 +508,18 @@ class Model_Temporal extends Model
 		// restore anything.
         
         $id = array();
-        $pk = static::getNonTimestampPks();
+        $pks = static::getNonTimestampPks();
         
-        if (count($pk) > 1)
+        if (count($pks) > 1)
         {
-		    foreach($pk as $key)
+		    foreach($pks as $key)
 		    {
                 $id[] = $this->{$key};
 		    }
         }
         else
         {
-            $id[] = $this->id;
+            $id[] = $this->{$pks[0]};
         }
         
 		$activeRow = static::find($id);


### PR DESCRIPTION
This will affect only when you have more primary keys than the default (id, temporal_start, temporal_end);

``` php
class Model_Example extends \Orm\Model_Temporal
{
    protected static $_primary_key = array('id', 'fk_id', 'fk2_id', 'temporal_start', 'temporal_end');
}
```

It will use the function getNonTimestampPks() and add it to the where conditions before sending the query to execute.

Be noted when you use the find, find_revision, find_revisions_between, you must inform all PKs (except temporal ones)

``` php
Model_Temporal::find(array($id, $fk_id, $fk2_id));
Model_Temporal::find_revision(array($id, $fk_id, $fk2_id), $temporal_start);
Model_Temporal::find_revisions_between(array($id, $fk_id, $fk2_id), $temporal_start, $temporal_end);
```

This edit also removed the $relations argument from find_revision.
Instead, you should provide the $options, as in any Model\Query instance;

``` php
array(
    'related' => array('related1', 'related2', 'relatedN'),
    'where' => array(),
)
```
