### PR TITLE
Avoid to destroy the overridden settings

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -316,6 +316,10 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 				if (is_string($p))
 				{
 					unset($properties[$key]);
+					if (isset($properties[$p]) and ! empty($properties[$p]))
+					{
+						continue;
+					}
 					$properties[$p] = array();
 				}
 			}


### PR DESCRIPTION
Current orm will override settings by empty array, when $_properties were something like this.

``` php
$_properties = [
    0 => 'id',
    'id' => ['data_type', 'int'],
];
```

will became

``` php
$_properties = [
    'id' => [],
];
```

Order of the definition won't help to avoid this problem.

By this PR, orm will no longer destroy any overridden settings.
