### PR TITLE
Error occured if the left-hand side is Database_Expression instance

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -623,7 +623,7 @@ class Query
 		$or and $this->or_where_open();
 		foreach ($val as $k_w => $v_w)
 		{
-			if (is_array($v_w) and ! empty($v_w[0]) and is_string($v_w[0]))
+			if (is_array($v_w) and ! empty($v_w[0]) and (is_string($v_w[0]) || $v_w[0] instanceof \Database_Expression))
 			{
 				! $v_w[0] instanceof \Database_Expression and strpos($v_w[0], '.') === false and $v_w[0] = $base.$v_w[0];
 				call_fuel_func_array(array($this, ($k_w === 'or' ? 'or_' : '').'where'), $v_w);

--- a/classes/query.php
+++ b/classes/query.php
@@ -623,7 +623,7 @@ class Query
 		$or and $this->or_where_open();
 		foreach ($val as $k_w => $v_w)
 		{
-			if (is_array($v_w) and ! empty($v_w[0]) and (is_string($v_w[0]) || $v_w[0] instanceof \Database_Expression))
+			if (is_array($v_w) and ! empty($v_w[0]) and (is_string($v_w[0]) or $v_w[0] instanceof \Database_Expression))
 			{
 				! $v_w[0] instanceof \Database_Expression and strpos($v_w[0], '.') === false and $v_w[0] = $base.$v_w[0];
 				call_fuel_func_array(array($this, ($k_w === 'or' ? 'or_' : '').'where'), $v_w);


### PR DESCRIPTION
At this case

``` php
$post = Model_Post::find('first', array(
    'where' => array(
        array(DB::expr("unix_timestamp(concat(year, '-', month, '-', day))"), '<', time())
    ),
    'order_by' => array('year' => 'desc', 'month' => 'desc', 'day' => 'desc')
));
```

I got "Runtime Recoverable error".

```
Fuel\Core\PhpErrorException [ Runtime Recoverable error ]:
Argument 1 passed to Orm\Query::_parse_where_array() must be of the type array, object given, called in C:\dev\dcross\fuel\packages\orm\classes\query.php on line 579 and defined
```
