### PR TITLE
Fix merging related data in many_many relation.

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1195,9 +1195,15 @@ class Query
 		}
 
 		// if the result to be generated is an array and the current object is not yet in there
-		if (is_array($result->data) and ! array_key_exists($pk, $result->data))
-		{
-			$result->data[$pk] = $obj;
+		if (is_array($result->data)) {
+			if (! array_key_exists($pk, $result->data))
+			{
+				$result->data[$pk] = $obj;
+			}
+			else
+			{
+				$obj = $result->data[$pk];
+			}
 		}
 		// if the result to be generated is a single object and empty
 		elseif ( ! is_array($result->data) and empty($result->data))


### PR DESCRIPTION
I found bug with many_many relation. This P-R fix it.
## Test environment
### Create table

``` sql
create table t1 (
  id integer primary key,
  v1 varchar(255)
);
create table t2 (
  id integer primary key,
  v2 varchar(255)
);
create table t1_t2_map (
  t1_id integer,
  t2_id integer
);
insert into t1 (id, v1) value (1, 'foo');
insert into t2 (id, v2) value (1, 'bar');
insert into t2 (id, v2) value (2, 'baz');
insert into t1_t2_map (t1_id, t2_id) value (1, 1);
insert into t1_t2_map (t1_id, t2_id) value (1, 2);
```
## Inserted data

```
mysql> select * from t1;
+----+------+
| id | v1   |
+----+------+
|  1 | foo  |
+----+------+
1 row in set (0.00 sec)

mysql> select * from t2;
+----+------+
| id | v2   |
+----+------+
|  1 | bar  |
|  2 | baz  |
+----+------+
2 rows in set (0.00 sec)

mysql> select * from t1_t2_map;
+-------+-------+
| t1_id | t2_id |
+-------+-------+
|     1 |     1 |
|     1 |     2 |
+-------+-------+
2 rows in set (0.00 sec)
```
## Model Classes
- Model_T1

``` php
class Model_T1 extends \Orm\Model
{
    /**
     * @var table name
     */
    protected static $_table_name = 't1';

    /**
     * relation definition
     */
    protected static $_many_many = [
        't2' => [
            'key_from' => 'id',
            'table_through' => 't1_t2_map',
            'key_through_from' => 't1_id',
            'key_through_to' => 't2_id',
            'model_to' => 'Model_T2',
            'key_to' => 'id',
            'cascade_save' => false,
            'cascade_delete' => false,
        ],
    ];
}
```
- Model_T2

``` php
class Model_T2 extends \Orm\Model
{
    /**
     * @var table name
     */
    protected static $_table_name = 't2';
}
```
## Reproduce bug

``` php
        $result = \Model_T1::query()
            ->related('t2')
            ->get_one();
        var_dump($result->to_array());
```

Result:

``` php
array(3) {
  ["id"]=>
  int(1)
  ["v1"]=>
  string(3) "foo"
  ["t2"]=>
  array(1) {
    [1]=>
    array(2) {
      ["id"]=>
      int(1)
      ["v2"]=>
      string(3) "bar"
    }
  }
}
```

After this patch, correct result:

``` php
array(3) {
  ["id"]=>
  int(1)
  ["v1"]=>
  string(3) "foo"
  ["t2"]=>
  array(2) {
    [1]=>
    array(2) {
      ["id"]=>
      int(1)
      ["v2"]=>
      string(3) "bar"
    }
    [2]=>
    array(2) {
      ["id"]=>
      int(2)
      ["v2"]=>
      string(3) "baz"
    }
  }
}
```
