### PR TITLE
Fix incorrect integer change detection when updating a model

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1446,18 +1446,30 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		// Create the query and limit to primary key(s)
 		$query       = Query::forge(get_called_class(), static::connection(true));
 		$primary_key = static::primary_key();
-		$properties  = array_keys(static::properties());
+		$properties  = static::properties();
+		$properties_keys  = array_keys($properties);
 		//Add the primary keys to the where
 		$this->add_primary_keys_to_where($query);
 
 		// Set all current values
-		foreach ($properties as $p)
+		foreach ($properties_keys as $p)
 		{
 			if ( ! in_array($p, $primary_key) )
 			{
 				if (array_key_exists($p, $this->_original))
 				{
-					$this->{$p} !== $this->_original[$p] and $query->set($p, isset($this->_data[$p]) ? $this->_data[$p] : null);
+					if ((array_key_exists('type', $properties[$p]) and $properties[$p]['type'] == 'int') or
+						(array_key_exists('data_type', $properties[$p]) and $properties[$p]['data_type'] == 'int'))
+					{
+						if ($this->{$p} != $this->_original[$p])
+						{
+							$query->set($p, isset($this->_data[$p]) ? $this->_data[$p] : null);
+						}
+					}
+					elseif ($this->{$p} !== $this->_original[$p])
+					{
+						$query->set($p, isset($this->_data[$p]) ? $this->_data[$p] : null);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
When a model update is triggered via save() method all fields with the 'data_type' property set to "int" will also get incorrectly marked for update. This means any integer fields will always be updated even if their values have not change.

## Changes
- Fix incorrect integer change detection when updating a model. If the model data type is set to 'int' then use a soft comparison exactly like the is_changed() method by checking the data_type and using loose comparison instead of strict comparison.

## Steps to Test
1. Create an example model with an integer data type
```
'some_example_string' => [
            'default' => "",
            'null' => false
        ],
'some_example_integer' => [
            'data_type' => 'int',
            'default' => 0,
            'null' => false
        ],
```
2. 

```
$myModel = My_Model::find(1);
$myModel->some_example_string = 'foo';
$myModel->save();

echo DB::last_query();
```
3. Validate `some_example_integer` is not being updated as part of the update query.