### PR TITLE
Bugfix diff

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -1816,12 +1816,13 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 			$rel = static::relations($key);
 			if ($rel->singular)
 			{
-				$new_pk = null;
+				$new_pk = empty($val) ? null : $val->implode_pk($val);
 				if (empty($this->_original_relations[$key]) !== empty($val)
 					or ( ! empty($this->_original_relations[$key]) and ! empty($val)
-						and $this->_original_relations[$key] !== $new_pk = $val->implode_pk($val)
+						and $this->_original_relations[$key] !== $new_pk
 					))
 				{
+
 					$diff[0][$key] = isset($this->_original_relations[$key]) ? $this->_original_relations[$key] : null;
 					$diff[1][$key] = isset($val) ? $new_pk : null;
 				}

--- a/classes/model.php
+++ b/classes/model.php
@@ -1718,6 +1718,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		$properties = static::properties();
 		$relations = static::relations();
 		$property = (array) $property ?: array_merge(array_keys($properties), array_keys($relations));
+		$simple_data_types = ['int','bool'];
 
 		foreach ($property as $p)
 		{
@@ -1725,8 +1726,8 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 			{
 				if (array_key_exists($p, $this->_original))
 				{
-					if ((array_key_exists('type', $properties[$p]) and $properties[$p]['type'] == 'int') or
-						(array_key_exists('data_type', $properties[$p]) and $properties[$p]['data_type'] == 'int'))
+					if ((array_key_exists('type', $properties[$p]) and in_array($properties[$p]['type'], $simple_data_types)) or
+						(array_key_exists('data_type', $properties[$p]) and in_array($properties[$p]['data_type'], $simple_data_types)))
 					{
 						if ($this->{$p} != $this->_original[$p])
 						{

--- a/classes/model.php
+++ b/classes/model.php
@@ -1718,7 +1718,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		$properties = static::properties();
 		$relations = static::relations();
 		$property = (array) $property ?: array_merge(array_keys($properties), array_keys($relations));
-		$simple_data_types = ['int','bool'];
+		$simple_data_types = array('int','bool');
 
 		foreach ($property as $p)
 		{


### PR DESCRIPTION
Reopen #396 and #401 - it seems we delete branches when we update from fuel's ORM. I thought I had that fixed.

Fixes a couple of issues with the difference engine.

Current issues:
- showing "null" for both values when showing the difference for a singular relation - specifically when adding a relation where there wasn't one before
- strict comparison of values for boolean fields (matching type)

These now:
- show the difference exactly for a singular relation when adding a relation where there wasn't one before
- loose comparison of values for boolean fields (not matching type)

Now 5.3.3 compatible.