### PR TITLE
Add a method to get the primary key's as an associative array

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -2170,6 +2170,22 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 	}
 
 	/**
+	 * Provide the identifying details in the form of an array
+	 *
+	 * @return array
+	 */
+	public function get_pk_assoc()
+	{
+		$array = array_flip(static::primary_key());
+
+		foreach($array as $key => &$value) {
+			$value = $this->get($key);
+		}
+
+		return $array;
+	}
+
+	/**
 	 * Allow converting this object to a real object
 	 *
 	 * @return  object

--- a/classes/model.php
+++ b/classes/model.php
@@ -2178,7 +2178,8 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 	{
 		$array = array_flip(static::primary_key());
 
-		foreach($array as $key => &$value) {
+		foreach ($array as $key => &$value)
+		{
 			$value = $this->get($key);
 		}
 


### PR DESCRIPTION
Re-open #399 and #402 - it seems we delete branches when we update from fuel's ORM. I thought I had that fixed.

Provides the primary key in a specifically defined array that should be all that is necessary to reverse-lookup the item

This is the effective rebase of the work done for #383