### PR TITLE
fix hydration losing relations when using from_cache(false)

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1406,6 +1406,11 @@ class Query
 		$pk  = count($primary_key) == 1 ? reset($obj) : '['.implode('][', $obj).']';
 		$obj = $this->from_cache ? Model::cached_object($pk, $model) : false;
 
+		// if the result already (partially) exists, use it
+		if (!is_array($result->data) and !empty($result->data)) {
+			$obj = $result->data;
+		}
+
 		// Create the object when it wasn't found
 		if ( ! $obj)
 		{


### PR DESCRIPTION
Resolves #407 by ensuring we do not discard the hydration progress made in previous hydrate() calls.

The block could also be moved down to [line 1479](https://github.com/SynergiTech/fuel-orm/blob/1c3eb17c4ee640b7c59a172775ae53ab33bb7370/classes/query.php#L1479) but would not benefit from the additional hydration performed on [line 1438](https://github.com/SynergiTech/fuel-orm/blob/1c3eb17c4ee640b7c59a172775ae53ab33bb7370/classes/query.php#L1438) onward.