### PR TITLE
Make \Orm\Model class more easily extended

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -614,7 +614,7 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 		if (is_null($id))
 		{
 			// if no options are present, simply return null. a PK with a null value can exist
-			return func_num_args() === 2 ? static::query($options) : null;
+			return empty($options) ? null : static::query($options);
 		}
 
 		// Return all that match $options array


### PR DESCRIPTION
I have a class that extends the `\Orm\Model` class (called `\MyNamespace\Model`). One of the methods it overrides is `Model::find` which calls `parent::find($id, $options)` which always has `func_num_args() === 2` even when the caller of the parent class left the `$options` field empty.

I ran a script that executed:

```
$model = \MyNamespace\Model::find(null);
$model->delete();
``` 

This caused an entire table to be truncated when I would have expected an error `cannot call method delete on null`. 


