### PR TITLE
Issue with observer self

### DIFF
--- a/classes/model.php
+++ b/classes/model.php
@@ -962,6 +962,37 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 			$this->observe('after_create');
 		}
 	}
+	
+	/**
+	* This method trigger the after_load observer event for non-new instances.
+	*/
+	public function trigger_after_load_recursive()
+	{
+		if( $this->_is_new)
+		{
+			return;
+		}
+
+		$this->observe('after_load');
+
+		if( $this->_data_relations )
+		{
+			foreach ( $this->_data_relations as $relation ) 
+			{
+				if ( is_array ( $relation ) )
+				{
+					foreach ($relation as $model) 
+					{
+						$model->trigger_after_load_recursive();
+					}
+				}
+				else if ( $relation instanceof Model )
+				{
+					$relation->trigger_after_load_recursive();
+				}
+			}
+		}
+	}
 
 	/**
 	 * Update the original setting for this object

--- a/classes/model.php
+++ b/classes/model.php
@@ -945,9 +945,6 @@ class Model implements \ArrayAccess, \Iterator, \Sanitization
 
 			// mark the object as existing
 			$this->_is_new = false;
-
-			// and fire the after-load observers
-			$this->observe('after_load');
 		}
 		else
 		{

--- a/classes/query.php
+++ b/classes/query.php
@@ -1579,6 +1579,11 @@ class Query
 
 		// It's all built, now lets execute and start hydration
 		return $result->data;
+		
+		foreach ($result->data as $model) 
+		{
+			$model->trigger_after_load_recursive();
+		}
 	}
 
 	/**

--- a/classes/query.php
+++ b/classes/query.php
@@ -1576,14 +1576,14 @@ class Query
 			$this->hydrate($row, $models, $result, $model, $select, $primary_key);
 			unset($rows[$id]);
 		}
-
-		// It's all built, now lets execute and start hydration
-		return $result->data;
 		
 		foreach ($result->data as $model) 
 		{
 			$model->trigger_after_load_recursive();
 		}
+
+		// It's all built, now lets execute and start hydration
+		return $result->data;
 	}
 
 	/**


### PR DESCRIPTION
This pull request address issue discussed in this forum thread : https://fuelphp.com/forums/discussion/15221/issue-with-observer-self

This was happening because the after_load observer event was triggered in the Model consutructor for non-new models, before relations are all set up.

After some analysis of the code, the way I fixed it was : 
- Remove it from the constructor
- Add a method that would trigger it, and call the method recursively in all the relations
- Call this method at the end of the get() method of the Orm\Query class.

I did some tests, didn't find any issue with this behavior. Let me know if anything more is needed, or if I forgot some use cases.

Cheers, 