### PR TITLE
fix select with alias column

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -527,7 +527,7 @@ class Query
 			$out = array();
 			foreach($this->select as $k => $v)
 			{
-				$out[] = is_array($v) ? array($v[0], $k) : array($v, $k);
+				$out[] = is_array($v) ? array($v[1], $k) : array($v, $k);
 			}
 
 			// set select back to before the PKs were added


### PR DESCRIPTION
I would like to select with `sum` function, like sample code below.
in 1.8, the code worked, but not in 1.9 now.

I believe this pull request fix it, but the code is too mature..

```
class Model_Temp extends Orm\Model {

    public static function _init() {
        static::$_table_name = $table = 'temp_' . time();

        DB::query(<<<SQL
                CREATE TEMPORARY TABLE {$table} (
                    `id`            int(11) not null auto_increment,
                    `value`         varchar(255) null,
                    primary key (`id`)
                );
                SQL
        )->execute();
    }

    protected static $_table_name  = null;
    protected static $_primary_key = ['id'];
    protected static $_properties  = [
        'id',
        'value',
    ];
}


Model_Temp::forge(['value' => 10])->save();
Model_Temp::forge(['value' => 20])->save();
Model_Temp::forge(['value' => 30])->save();

$data = Model_Temp::query(['select' => [[DB::expr('sum(value)'), 'total']]])
                  ->get_one();


echo $data->total;
```