### PR TITLE
Fix regression caused by last pull request in query.php

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -1582,7 +1582,7 @@ class Query
 						$new = array();
 						foreach ($record as $column => $value)
 						{
-							if (isset($obj->{$column}))
+							if ( ! isset($obj->{$column}))
 							{
 								$obj->{$column} = $value;
 								$new[$column] = $value;


### PR DESCRIPTION
When including your reviews regarding my last pull request, I replaced the `empty` check by `isset` instead of `! isset`

This would cause to override all property already defined from cached objects. If observer_typing is used, existing and typed properties would then be replaced by non typed values from db and so invalidate it.

My bad.