### PR TITLE
fix select with alias column

### DIFF
--- a/classes/query.php
+++ b/classes/query.php
@@ -527,7 +527,14 @@ class Query
 			$out = array();
 			foreach($this->select as $k => $v)
 			{
-				$out[] = is_array($v) ? array($v[1], $k) : array($v, $k);
+				if (is_array($v))
+				{
+					$out[$v[1]] = array($v[0], $k);
+				}
+				else
+				{
+					$out[] = array($v, $k);
+				}
 			}
 
 			// set select back to before the PKs were added
@@ -1384,7 +1391,7 @@ class Query
 				{
 					if ($value[0] instanceOf \Fuel\Core\Database_Expression)
 					{
-						$result[$key] = $value[1];
+						$result[$value[1]] = $key;
 					}
 					else
 					{
@@ -1414,7 +1421,7 @@ class Query
 			}
 		}
 
-		$query = call_fuel_func_array('DB::select', $select);
+		$query = call_fuel_func_array('DB::select', array_values($select));
 
 		// Set from view/table
 		$query->from(array($this->_table(), $this->alias));

--- a/classes/query.php
+++ b/classes/query.php
@@ -1150,7 +1150,7 @@ class Query
 			}
 
 			// make current query subquery of ultimate query
-			$new_query = call_fuel_func_array('DB::select', $columns);
+			$new_query = call_fuel_func_array('DB::select', array_values($columns));
 			$query = $new_query->from(array($query, $this->alias));
 		}
 		else

--- a/classes/query.php
+++ b/classes/query.php
@@ -529,7 +529,14 @@ class Query
 			{
 				if (is_array($v))
 				{
-					$out[$v[1]] = array($v[0], $k);
+					if (count($v) === 1)
+					{
+						$out[] = array($v[0], $k);
+					}
+					else
+					{
+						$out[$v[1]] = array($v[0], $k);
+					}
 				}
 				else
 				{

--- a/classes/query.php
+++ b/classes/query.php
@@ -1601,7 +1601,7 @@ class Query
 				$select[] = $c[0];
 			}
 		}
-		$query = call_fuel_func_array('DB::select', $select);
+		$query = call_fuel_func_array('DB::select', array_values($select));
 
 		// Set the defined connection on the query
 		$query->set_connection($this->connection);


### PR DESCRIPTION
Previous PR https://github.com/fuel/orm/pull/432 doesn't work right now.

sample code.
```
class Model_Temp extends Orm\Model {

    public static function _init() {
        static::$_table_name = $table = 'temp_' . time();

        DB::query(<<<SQL
                CREATE TEMPORARY TABLE {$table} (
                    `id`            int(11) not null auto_increment,
                    `value`         varchar(255) null,
                    primary key (`id`)
                );
                SQL
        )->execute();
    }

    protected static $_table_name  = null;
    protected static $_primary_key = ['id'];
    protected static $_properties  = [
        'id',
        'value',
    ];
}


Model_Temp::forge(['value' => 10])->save();
Model_Temp::forge(['value' => 20])->save();
Model_Temp::forge(['value' => 30])->save();
Model_Temp::flush_cache();

$data = Model_Temp::query(['select' => [[DB::expr('sum(value)'), 'total']]])
                  ->get_one();


echo $data->total;
```
